### PR TITLE
hotfix/response-type-data-type

### DIFF
--- a/packages/okta-angular/src/okta/okta.config.ts
+++ b/packages/okta-angular/src/okta/okta.config.ts
@@ -16,7 +16,7 @@ export interface OktaConfig {
   issuer?: string;
   redirectUri?: string;
   clientId?: string;
-  responseType?: string;
+  responseType?: string | string[];
   scopes?: any[];
 }
 


### PR DESCRIPTION
The data type for OktaConfig.responseType needs to be extended to allow for either a string or an array of strings.