### PR TITLE
Fixed two issues when responseType is id_token only:

### DIFF
--- a/packages/okta-angular/src/okta/okta.service.ts
+++ b/packages/okta-angular/src/okta/okta.service.ts
@@ -63,10 +63,10 @@ export class OktaAuthService {
     }
 
     /**
-     * Checks if there is a current accessToken in the TokenManager.
+     * Checks if there is a current accessToken or idToken in the TokenManager.
      */
     isAuthenticated() {
-      return !!this.oktaAuth.tokenManager.get('accessToken');
+      return !!this.oktaAuth.tokenManager.get('accessToken') || !!this.oktaAuth.tokenManager.get('idToken');
     }
 
     /**
@@ -114,7 +114,8 @@ export class OktaAuthService {
      * Parses the tokens from the callback URL.
      */
     async handleAuthentication() {
-      const tokens = await this.oktaAuth.token.parseFromUrl();
+      let tokens = await this.oktaAuth.token.parseFromUrl();
+      tokens = Object.prototype.toString.call(tokens) === '[object Array]' ? tokens : [tokens];
       tokens.forEach(token => {
         if (token.idToken) {
           this.oktaAuth.tokenManager.add('idToken', token);


### PR DESCRIPTION
When responseType is set to id_token only there are two issues.
1) handleAuthentication is expecting the tokens variable to be an array, but it is an object. If it is an object then the call to forEach results in an unhandled exception. To prevent this, first check if the tokens is an array and if not create a new array with the tokens as the only entry.
2) if an access_token was not requested, then isAuthenticated will always return false even if a valid id_token is returned. To handle this case, check for either access_token or idToken inside isAuthenticated.