### PR TITLE
:bug: Modifies build to happen before start/test

### DIFF
--- a/packages/okta-vue/package.json
+++ b/packages/okta-vue/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "prestart": "npm run build",
     "pretest": "npm run build",
+    "prepublish": "npm run build",
     "test": "npm run --prefix test/e2e/harness/ e2e",
     "start": "npm run --prefix test/e2e/harness/ start",
     "build": "rimraf dist/ && cross-env NODE_ENV=production webpack --config webpack.config.js --output-library-target=umd -p",

--- a/packages/okta-vue/package.json
+++ b/packages/okta-vue/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@okta/okta-vue",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Vue support for Okta",
   "main": "dist/okta-vue.js",
   "scripts": {
-    "postinstall": "npm run build",
+    "prestart": "npm run build",
+    "pretest": "npm run build",
     "test": "npm run --prefix test/e2e/harness/ e2e",
     "start": "npm run --prefix test/e2e/harness/ start",
     "build": "rimraf dist/ && cross-env NODE_ENV=production webpack --config webpack.config.js --output-library-target=umd -p",


### PR DESCRIPTION
When running `lerna boostrap`, it goes through each `package` and runs `npm install`. Previously, we had a `postinstall` script (different than Angular and React's implementation), which caused our `publish.sh` script to fail.

This updates the `package.json` scripts to follow the same structure used in Angular + React.