### PR TITLE
Fixes vue-loader version

### DIFF
--- a/packages/okta-vue/.babelrc
+++ b/packages/okta-vue/.babelrc
@@ -6,7 +6,7 @@
   "plugins": ["transform-runtime"],
   "env": {
     "test": {
-      "presets": ["env", "stage-2"]
+      "presets": ["env", "stage-2", "es2015"]
     }
   }
 }

--- a/packages/okta-vue/package.json
+++ b/packages/okta-vue/package.json
@@ -54,7 +54,7 @@
     "rimraf": "^2.6.2",
     "uglifyjs-webpack-plugin": "^1.1.1",
     "url-loader": "^0.5.8",
-    "vue-loader": "^13.3.0",
+    "vue-loader": "12.2.2",
     "vue-style-loader": "^3.0.1",
     "vue-template-compiler": "^2.5.2",
     "webpack": "^3.6.0"

--- a/packages/okta-vue/package.json
+++ b/packages/okta-vue/package.json
@@ -54,7 +54,7 @@
     "rimraf": "^2.6.2",
     "uglifyjs-webpack-plugin": "^1.1.1",
     "url-loader": "^0.5.8",
-    "vue-loader": "12.2.2",
+    "vue-loader": "13.0.2",
     "vue-style-loader": "^3.0.1",
     "vue-template-compiler": "^2.5.2",
     "webpack": "^3.6.0"

--- a/packages/okta-vue/test/e2e/harness/package.json
+++ b/packages/okta-vue/test/e2e/harness/package.json
@@ -58,7 +58,7 @@
     "shelljs": "^0.7.6",
     "uglifyjs-webpack-plugin": "^1.1.1",
     "url-loader": "^0.5.8",
-    "vue-loader": "^13.3.0",
+    "vue-loader": "12.2.2",
     "vue-style-loader": "^3.0.1",
     "vue-template-compiler": "^2.5.2",
     "webpack": "^3.6.0",

--- a/packages/okta-vue/test/e2e/harness/package.json
+++ b/packages/okta-vue/test/e2e/harness/package.json
@@ -58,7 +58,7 @@
     "shelljs": "^0.7.6",
     "uglifyjs-webpack-plugin": "^1.1.1",
     "url-loader": "^0.5.8",
-    "vue-loader": "12.2.2",
+    "vue-loader": "13.0.2",
     "vue-style-loader": "^3.0.1",
     "vue-template-compiler": "^2.5.2",
     "webpack": "^3.6.0",

--- a/packages/okta-vue/webpack.config.js
+++ b/packages/okta-vue/webpack.config.js
@@ -18,10 +18,7 @@ module.exports = {
       },
       {
         test: /\.vue$/,
-        loader: 'vue-loader',
-        options: {
-          loaders: {}
-        }
+        loader: 'vue-loader'
       },
       {
         test: /\.js$/,


### PR DESCRIPTION
As noted [here](https://github.com/vuejs/vue-loader/issues/1010) and many other places around the web, `vue-loader 13.x` doesn't work well with npm versions `< 6`. Dropping the version down to `12.2.2` allows webpack to properly build `.vue` files.