### PR TITLE
Update publish script

### DIFF
--- a/scripts/publish_registry.js
+++ b/scripts/publish_registry.js
@@ -26,7 +26,13 @@ dirs.forEach(name => {
   const moduleWithVersion = `${pkg.name}@${pkg.version}`;
 
   console.log(`Checking if ${moduleWithVersion} exists`);
-  const isInPublicNpm = !!execSync(`npm view ${moduleWithVersion} --registry ${registry}`).toString();
+
+  try {
+    const isInPublicNpm = !!execSync(`npm view ${moduleWithVersion} --registry ${registry}`).toString();
+  } catch (err) {
+    // We expect packages that do not exist to throw a 404 error
+  }
+
   if (isInPublicNpm) {
     console.log(`${moduleWithVersion} exists`);
   } else {

--- a/scripts/publish_registry.js
+++ b/scripts/publish_registry.js
@@ -32,7 +32,7 @@ dirs.forEach(name => {
     isInPublicNpm = !!execSync(`npm view ${moduleWithVersion} --registry ${registry}`).toString();
   } catch (err) {
     // We expect packages that do not exist to throw a 404 error
-    console.log(`${pkg.name} does not have have any published versions`);
+    console.log(`${pkg.name} does not have any published versions`);
   }
 
   if (isInPublicNpm) {

--- a/scripts/publish_registry.js
+++ b/scripts/publish_registry.js
@@ -27,10 +27,12 @@ dirs.forEach(name => {
 
   console.log(`Checking if ${moduleWithVersion} exists`);
 
+  let isInPublicNpm = false;
   try {
-    const isInPublicNpm = !!execSync(`npm view ${moduleWithVersion} --registry ${registry}`).toString();
+    isInPublicNpm = !!execSync(`npm view ${moduleWithVersion} --registry ${registry}`).toString();
   } catch (err) {
     // We expect packages that do not exist to throw a 404 error
+    console.log(`${pkg.name} does not have have any published versions`);
   }
 
   if (isInPublicNpm) {


### PR DESCRIPTION
Currently`execSync` script throws an error if a package doesn't exist in the npm registry. Surrounding this with a simple `try catch` will catch the `404` error and publish it as a new version.