### PR TITLE
Add tokenManager to OktaAuth config

### DIFF
--- a/packages/okta-react/README.md
+++ b/packages/okta-react/README.md
@@ -178,6 +178,12 @@ Security is the top-most component of okta-react. This is where most of the conf
     1. `auth.login` is called
     2. SecureRoute is accessed without authentication
 
+* **tokenManager** (optional)
+  Specify where the Okta token will be stored. Default is `localStorage`.
+  * `localStorage`
+  * `sessionStorage`
+  * `cookie`
+
 #### Example
 
 ```typescript

--- a/packages/okta-react/src/Auth.js
+++ b/packages/okta-react/src/Auth.js
@@ -20,7 +20,8 @@ export default class Auth {
       url: config.issuer.split('/oauth2/')[0],
       clientId: config.client_id,
       issuer: config.issuer,
-      redirectUri: config.redirect_uri
+      redirectUri: config.redirect_uri,
+      tokenManager: config.token_manager || 'localStorage'
     });
     this._config = config;
     this._history = config.history;


### PR DESCRIPTION
This PR extends the config object in Auth.js to accept `tokenManager`, falling back to the default 'localStorage' (as defined in [TokenManager.js](https://github.com/okta/okta-auth-js/blob/master/lib/TokenManager.js#L134)) if not specified. Supported in the [OktaAuth spec](https://github.com/okta/okta-auth-js/blob/master/lib/clientBuilder.js#L141).