### PR TITLE
:bug: Fixes fromUri path + adds param during login and logout for navigation

### DIFF
--- a/packages/okta-angular/README.md
+++ b/packages/okta-angular/README.md
@@ -172,8 +172,17 @@ const oktaConfig = {
 ```
 
 ## Reference
-### `oktaAuth`
-`oktaAuth` is the top-most component of `okta-angular`. This is where most of the configuration is provided.
+### Service Module
+In your main `NgModule`, your can take advantage of all of `okta-angular`'s features by importing the following:
+
+```typescript
+import {
+  OktaAuthGuard,
+  OktaAuthModule,
+  OktaCallbackComponent,
+  OktaLoginRedirectComponent
+} from '@okta/okta-angular';
+```
 
 #### Configuration Options
   - `issuer` **(required)**: The OpenID Connect `issuer`
@@ -182,10 +191,35 @@ const oktaConfig = {
   - `scope` *(optional)*: Reserved or custom claims to be returned in the tokens
   - `onAuthRequired` *(optional)*: Accepts a callback to make a decision when authentication is required. If not supplied, `okta-angular` will redirect directly to Okta for authentication.
 
+> An example of this configuration can be seen [above](#configuration).
+
+### Component Usage
+All the methods mentioned below are available in your components. Simply import them in as shown:
+
+```typescript
+import { OktaAuthService } from '@okta/okta-angular';
+
+@Component({
+  selector: 'app-component',
+  template: `
+  <button *ngIf="!oktaAuth.isAuthenticated()" (click)="oktaAuth.loginRedirect('/profile')> Login </button>
+  <button *ngIf="oktaAuth.isAuthenticated()" (click)="oktaAuth.logout('/')"> Logout </button>
+
+  <router-outlet></router-outlet>
+  `,
+})
+export class MyComponent {
+
+  constructor(public oktaAuth: OktaAuthService) {
+    // ...
+  }
+}
+```
+
 #### `oktaAuth.loginRedirect(uri, additionalParams?)`
 Performs a full page redirect to Okta based on the initial configuration.  On successful authentication, the router will navigate to the path specified with the `uri` parameter. 
 
-If you have an Okta `sessionToken`, you can bypass the full-page redirect by passing in this token. This is recommended when using the [Okta Sign-In Widget](https://github.com/okta/okta-signin-widget). Simply pass in a `sessionToken` into the `loginRedirect` method follows:
+The optional parameter `additionalParams` is mapped to the [AuthJS OpenID Connect Options](https://github.com/okta/okta-auth-js#openid-connect-options). This will override any existing [configuration](#configuration). As an example, if you have an Okta `sessionToken`, you can bypass the full-page redirect by passing in this token. This is recommended when using the [Okta Sign-In Widget](https://github.com/okta/okta-signin-widget). Simply pass in a `sessionToken` into the `loginRedirect` method follows:
 
 ```typescript
 // Navigate to "/profile" on login success
@@ -211,7 +245,7 @@ Returns the result of the OpenID Connect `/userinfo` endpoint if an access token
 #### `oktaAuth.handleAuthentication()`
 Parses the tokens returned as hash fragments in the OAuth 2.0 Redirect URI.
 
-### `oktaAuth.logout(uri?)`
+#### `oktaAuth.logout(uri?)`
 Terminates the user's session in Okta and clears all stored tokens.  Takes an optional `uri` parameter (defaults to `/`) for navigation once complete.
 
 #### `oktaAuth.getOktaAuth()`

--- a/packages/okta-angular/src/okta/okta.service.ts
+++ b/packages/okta-angular/src/okta/okta.service.ts
@@ -100,11 +100,7 @@ export class OktaAuthService {
      * @param fromUri
      * @param additionalParams
      */
-<<<<<<< HEAD
     loginRedirect(fromUri?: string, additionalParams?: object) {
-=======
-    loginRedirect(fromUri: String, additionalParams?: object) {
->>>>>>> :bug: Fixes fromUri path + updates legal headers
       // Set the from URI
       this.setFromUri(fromUri || '/');
 

--- a/packages/okta-angular/src/okta/okta.service.ts
+++ b/packages/okta-angular/src/okta/okta.service.ts
@@ -100,7 +100,11 @@ export class OktaAuthService {
      * @param fromUri
      * @param additionalParams
      */
+<<<<<<< HEAD
     loginRedirect(fromUri?: string, additionalParams?: object) {
+=======
+    loginRedirect(fromUri: String, additionalParams?: object) {
+>>>>>>> :bug: Fixes fromUri path + updates legal headers
       // Set the from URI
       this.setFromUri(fromUri || '/');
 


### PR DESCRIPTION
### Updates
- Automatically set `fromUri` value when the `AuthGuard` is triggered.
     - In the default case where no `onAuthRequired` is passed in, we pass the current `url` into the `loginRedirect` method. 
    - When `onAuthRequired` is passed in, the current url value must be set before executing the `onAuthRequired` method.
        - For example: `/protected` is blocked by the `OktaAuthGuard`, where a custom `onAuthRequired` logic navigates the user to `/login`.
- Update the default `OktaLoginRedirectComponent` to use either the default path `/` as the `fromUri` or the value provided by the `onAuthRequired` guard logic.
- Removes checking for the object type of scope (breaking change)
- Adds configurable url to redirect to after logout

### Resolves
#84 (Angular)