### PR TITLE
Remove array check on scopes

### DIFF
--- a/packages/okta-angular/src/okta/okta.service.ts
+++ b/packages/okta-angular/src/okta/okta.service.ts
@@ -155,13 +155,11 @@ export class OktaAuthService {
 
     /**
      * Scrub scopes to ensure 'openid' is included
+     * @param scopes
      */
-    scrubScopes(scopes) {
+    scrubScopes(scopes: string) {
       if (!scopes) {
         return 'openid email';
-      } else {
-        // Make sure object is a string
-        scopes = Array.isArray(scopes) ? scopes.join(' ') : scopes
       }
       if (scopes.indexOf('openid') === -1) {
         return scopes + ' openid';


### PR DESCRIPTION
BREAKING CHANGE

- Requires `scopes` passed in as a custom parameter to be a single `string`.
    - `openid profile email custom`
    - ~`['openid', 'profile', 'email', 'custom']`~ 