### PR TITLE
fix: Change default HTTP timeout to 10 seconds

### DIFF
--- a/packages/oidc-middleware/README.md
+++ b/packages/oidc-middleware/README.md
@@ -98,6 +98,7 @@ Optional config:
 * **scope** - Defaults to `openid`, which will only return the `sub` claim. To obtain more information about the user, use `openid profile`. For a list of scopes and claims, please see [Scope-dependent claims](https://developer.okta.com/standards/OIDC/index.html#scope-dependent-claims-not-always-returned) for more information.
 * **routes** - Allows customization of the generated routes. See [Customizing Routes](#customizing-routes) for details.
 * **maxClockSkew** - Defaults to 120. This is the maximum difference allowed between your server's clock and Okta's in seconds. Setting this to 0 is not recommended, because it increases the likelihood that valid jwts will fail verification due to `nbf` and `exp` issues.
+* **timeout** - Defaults to 10000 milliseconds. The HTTP max timeout for any requests to the issuer.  If a timeout exception occurs you can catch it with the `oidc.on('error', fn)` handler.
 
 ### oidc.router
 

--- a/packages/oidc-middleware/src/oidcUtil.js
+++ b/packages/oidc-middleware/src/oidcUtil.js
@@ -45,8 +45,11 @@ oidcUtil.createClient = context => {
     client_id,
     client_secret,
     redirect_uri,
-    maxClockSkew
+    maxClockSkew,
+    timeout
   } = context.options;
+
+  Issuer.defaultHttpOptions.timeout = timeout || 10000;
 
   return Issuer.discover(issuer)
   .then(iss => {


### PR DESCRIPTION
The internal default of node-openid-client is 1.5 seconds, which is proving to be too short.

Closes #85 #82 