### PR TITLE
:bug: Fixes redirect back to protected page

### DIFF
--- a/packages/okta-angular/src/okta/okta.guard.ts
+++ b/packages/okta-angular/src/okta/okta.guard.ts
@@ -52,7 +52,7 @@ export class OktaAuthGuard implements CanActivate {
     /** 
      * Store the current path
      */
-    this.oktaAuth.setFromUri(state.url);
+    this.oktaAuth.setFromUri(route.url[0].path, route.queryParams);
 
     /**
      * Redirect to the given path or

--- a/packages/okta-angular/src/okta/okta.guard.ts
+++ b/packages/okta-angular/src/okta/okta.guard.ts
@@ -52,7 +52,8 @@ export class OktaAuthGuard implements CanActivate {
     /** 
      * Store the current path
      */
-    this.oktaAuth.setFromUri(route.url[0].path, route.queryParams);
+    const path = state.url.split(/[?#]/)[0];
+    this.oktaAuth.setFromUri(path, route.queryParams);
 
     /**
      * Redirect to the given path or

--- a/packages/okta-angular/src/okta/okta.service.ts
+++ b/packages/okta-angular/src/okta/okta.service.ts
@@ -11,7 +11,7 @@
  */
 
 import { Inject, Injectable, Optional } from '@angular/core';
-import { Router } from '@angular/router';
+import { Router, NavigationExtras } from '@angular/router';
 
 import { OKTA_CONFIG } from './okta.config';
 
@@ -111,10 +111,15 @@ export class OktaAuthService {
 
     /**
      * Stores the intended path to redirect after successful login.
-     * @param uri 
+     * @param uri
+     * @param queryParams
      */
-    setFromUri(uri) {
-      localStorage.setItem('referrerPath', uri);
+    setFromUri(uri, queryParams) {
+      const json = JSON.stringify({
+        uri: uri,
+        params: queryParams
+      });
+      localStorage.setItem('referrerPath', json);
     }
 
     /**
@@ -143,7 +148,11 @@ export class OktaAuthService {
       /**
        * Navigate back to the initial view or root of application.
        */
-      this.router.navigate([this.getFromUri()]);
+      const path = JSON.parse(this.getFromUri());
+      const navigationExtras: NavigationExtras = {
+        queryParams: path.params
+      };
+      this.router.navigate([path.uri], navigationExtras);
     }
 
     /**

--- a/packages/okta-angular/test/e2e/harness/e2e/app.e2e-spec.ts
+++ b/packages/okta-angular/test/e2e/harness/e2e/app.e2e-spec.ts
@@ -55,6 +55,25 @@ describe('Angular + Okta App', () => {
     expect(protectedPage.getLoginButton().isPresent()).toBeTruthy();
   });
 
+  it('should redirect to Okta for login when trying to access a protected page with query params', () => {
+    protectedPage.navigateToWithQuery();
+
+    oktaLoginPage.waitUntilVisible();
+    oktaLoginPage.signIn({
+      username: environment.USERNAME,
+      password: environment.PASSWORD
+    });
+
+    protectedPage.waitUntilQueryVisible();
+    expect(protectedPage.getLogoutButton().isPresent()).toBeTruthy();
+
+    /**
+     * Logout
+     */
+    protectedPage.getLogoutButton().click();
+    expect(protectedPage.getLoginButton().isPresent()).toBeTruthy();
+  });
+
   /**
    * Hack to slowdown the tests due to the Okta session
    * not being removed in time for the second login call.

--- a/packages/okta-angular/test/e2e/harness/e2e/app.e2e-spec.ts
+++ b/packages/okta-angular/test/e2e/harness/e2e/app.e2e-spec.ts
@@ -55,7 +55,7 @@ describe('Angular + Okta App', () => {
     expect(protectedPage.getLoginButton().isPresent()).toBeTruthy();
   });
 
-  it('should redirect to Okta for login when trying to access a protected page with query params', () => {
+  it('should preserve query paramaters after redirecting to Okta', () => {
     protectedPage.navigateToWithQuery();
 
     oktaLoginPage.waitUntilVisible();

--- a/packages/okta-angular/test/e2e/harness/e2e/page-objects/protected.po.ts
+++ b/packages/okta-angular/test/e2e/harness/e2e/page-objects/protected.po.ts
@@ -18,8 +18,16 @@ export class ProtectedPage {
     return browser.get('/protected');
   }
 
+  navigateToWithQuery() {
+    return browser.get('/protected?state=foo');
+  }
+
   waitUntilVisible() {
     browser.wait(ExpectedConditions.urlContains('/protected'), 5000);
+  }
+
+  waitUntilQueryVisible() {
+    browser.wait(ExpectedConditions.urlContains('/protected?state=foo'), 5000);
   }
 
   getLogoutButton() {

--- a/packages/okta-angular/test/e2e/harness/e2e/page-objects/protected.po.ts
+++ b/packages/okta-angular/test/e2e/harness/e2e/page-objects/protected.po.ts
@@ -19,7 +19,7 @@ export class ProtectedPage {
   }
 
   navigateToWithQuery() {
-    return browser.get('/protected?state=foo');
+    return browser.get('/protected/foo?state=bar');
   }
 
   waitUntilVisible() {
@@ -27,7 +27,7 @@ export class ProtectedPage {
   }
 
   waitUntilQueryVisible() {
-    browser.wait(ExpectedConditions.urlContains('/protected?state=foo'), 5000);
+    browser.wait(ExpectedConditions.urlContains('/protected/foo?state=bar'), 5000);
   }
 
   getLogoutButton() {

--- a/packages/okta-angular/test/e2e/harness/src/app/app.module.ts
+++ b/packages/okta-angular/test/e2e/harness/src/app/app.module.ts
@@ -57,7 +57,14 @@ const appRoutes: Routes = [
   {
     path: 'protected',
     component: ProtectedComponent,
-    canActivate: [ OktaAuthGuard ]
+    canActivate: [ OktaAuthGuard ],
+    children: [
+      {
+        path: 'foo',
+        component: ProtectedComponent,
+        canActivate: [ OktaAuthGuard ]
+      }
+    ]
   },
   {
     path: 'protected-with-data',


### PR DESCRIPTION
BREAKING CHANGE

Fixes an issue where navigation back to a protected page was encoding the query parameters. Now, protected pages can include query params: `/protected?state=foo`

Resolves:
OKTA-161365
#123 