### PR TITLE
:seedling: Adds getUser method

### DIFF
--- a/packages/okta-angular/README.md
+++ b/packages/okta-angular/README.md
@@ -217,6 +217,9 @@ this.oktaAuth.loginRedirect({
 #### `oktaAuth.isAuthenticated()`
 Returns `true` if there is a valid access token or ID token.
 
+#### `oktaAuth.getUser()`
+Returns the result of the OpenID Connect `/userinfo` endpoint if an access token is provided or parses the available idToken.
+
 #### `oktaAuth.getAccessToken()`
 Returns the access token from storage (if it exists).
 

--- a/packages/okta-angular/src/okta/okta.service.ts
+++ b/packages/okta-angular/src/okta/okta.service.ts
@@ -89,6 +89,24 @@ export class OktaAuthService {
     }
 
     /**
+     * Returns user claims from the /userinfo endpoint if an
+     * accessToken is provided or parses the available idToken.
+     */
+    async getUser() {
+      const accessToken = this.oktaAuth.tokenManager.get('accessToken');
+      const idToken = this.oktaAuth.tokenManager.get('idToken');
+      if (accessToken && idToken) {
+        const userinfo = await this.oktaAuth.token.getUserInfo(accessToken);
+        if (userinfo.sub === idToken.claims.sub) {
+          // Only return the userinfo response if subjects match to
+          // mitigate token substitution attacks
+          return userinfo;
+        }
+      }
+      return idToken ? idToken.claims : undefined;
+    }
+
+    /**
      * Returns the configuration object used.
      */
     getOktaConfig(){

--- a/packages/okta-angular/test/e2e/harness/e2e/app.e2e-spec.ts
+++ b/packages/okta-angular/test/e2e/harness/e2e/app.e2e-spec.ts
@@ -48,6 +48,12 @@ describe('Angular + Okta App', () => {
     protectedPage.waitUntilVisible();
     expect(protectedPage.getLogoutButton().isPresent()).toBeTruthy();
 
+    // Verify the user object was returned
+    protectedPage.getUserInfo().getText()
+    .then(userInfo => {
+      expect(userInfo).toContain("email");
+    })
+
     // Logout
     protectedPage.getLogoutButton().click();
     expect(protectedPage.getLoginButton().isPresent()).toBeTruthy();

--- a/packages/okta-angular/test/e2e/harness/e2e/page-objects/protected.po.ts
+++ b/packages/okta-angular/test/e2e/harness/e2e/page-objects/protected.po.ts
@@ -29,4 +29,8 @@ export class ProtectedPage {
   getLoginButton() {
     return element(by.id('login-button'));
   }
+
+  getUserInfo() {
+    return element(by.id('userinfo-container'));
+  }
 }

--- a/packages/okta-angular/test/e2e/harness/protractor.conf.js
+++ b/packages/okta-angular/test/e2e/harness/protractor.conf.js
@@ -23,7 +23,7 @@ exports.config = {
   capabilities: {
     'browserName': 'chrome',
     chromeOptions: {
-      args: ['--headless','--disable-gpu','--window-size=1600x1200', '--no-sandbox']
+      args: ['--headless', '--disable-gpu', '--window-size=1600x1200', '--no-sandbox']
     }
   },
   directConnect: true,

--- a/packages/okta-angular/test/e2e/harness/src/app/protected.component.ts
+++ b/packages/okta-angular/test/e2e/harness/src/app/protected.component.ts
@@ -11,15 +11,25 @@
  */
 
 import { Component } from '@angular/core';
+import { OktaAuthService } from '@okta/okta-angular';
 
 @Component({
   selector: 'app-secure',
-  template: `{{message}}`
+  template: `
+  {{ message }}
+  <pre id="userinfo-container">{{ user }}</pre>
+  `
 })
 export class ProtectedComponent {
   message;
+  user;
 
-  constructor() {
-    this.message = 'Protected endpont!';
+  constructor(public oktaAuth: OktaAuthService) {
+    this.message = 'Protected!';
+  }
+
+  async ngOnInit() {
+    const user = await this.oktaAuth.getUser();
+    this.user = JSON.stringify(user, null, 4);
   }
 }


### PR DESCRIPTION
Adds a helper method to return a payload of user information, based on the available tokens.

This method considers the token substitution attack vector mentioned [here](http://openid.net/specs/openid-connect-core-1_0.html#TokenSubstitution), using the recommendations outlined in [OpenID Connect UserInfo response](http://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse).

- [x] If there is an `accessToken` and `idToken` ➡️ Return the most up-to-date record from the `/userinfo` endpoint.
- [x] If there is **no** `accessToken`, but an `idToken` is present ➡️ Decode the `idToken` payload.

Resolves: #107 