### PR TITLE
:bug: Fix flaky E2E angular tests

### DIFF
--- a/packages/okta-angular/test/e2e/harness/e2e/app.e2e-spec.ts
+++ b/packages/okta-angular/test/e2e/harness/e2e/app.e2e-spec.ts
@@ -39,7 +39,7 @@ describe('Angular + Okta App', () => {
   it('should redirect to Okta for login when trying to access a protected page', () => {
     protectedPage.navigateTo();
 
-    oktaLoginPage.waitUntilVisible();
+    oktaLoginPage.waitUntilVisible(environment.ISSUER);
     oktaLoginPage.signIn({
       username: environment.USERNAME,
       password: environment.PASSWORD
@@ -48,9 +48,7 @@ describe('Angular + Okta App', () => {
     protectedPage.waitUntilVisible();
     expect(protectedPage.getLogoutButton().isPresent()).toBeTruthy();
 
-    /**
-     * Logout
-     */
+    // Logout
     protectedPage.getLogoutButton().click();
     expect(protectedPage.getLoginButton().isPresent()).toBeTruthy();
   });
@@ -65,8 +63,7 @@ describe('Angular + Okta App', () => {
   it('should redirect to Okta for login', () => {
     loginPage.navigateTo();
 
-    oktaLoginPage.waitUntilVisible();
-
+    oktaLoginPage.waitUntilVisible(environment.ISSUER);
     oktaLoginPage.signIn({
       username: environment.USERNAME,
       password: environment.PASSWORD
@@ -75,9 +72,7 @@ describe('Angular + Okta App', () => {
     loginPage.waitUntilVisible();
     expect(loginPage.getLogoutButton().isPresent()).toBeTruthy();
 
-    /**
-     * Logout
-     */
+    // Logout
     loginPage.getLogoutButton().click();
     expect(loginPage.getLoginButton().isPresent()).toBeTruthy();
   });
@@ -86,7 +81,6 @@ describe('Angular + Okta App', () => {
     sessionTokenSignInPage.navigateTo();
 
     sessionTokenSignInPage.waitUntilVisible();
-
     sessionTokenSignInPage.signIn({
       username: process.env.USERNAME,
       password: process.env.PASSWORD
@@ -97,7 +91,6 @@ describe('Angular + Okta App', () => {
 
     // Logout
     page.getLogoutButton().click();
-
-    page.waitUntilLoggedOut();
+    expect(page.getLoginButton().isPresent()).toBeTruthy();
   });
 });

--- a/packages/okta-angular/test/e2e/harness/e2e/page-objects/okta-signin.po.ts
+++ b/packages/okta-angular/test/e2e/harness/e2e/page-objects/okta-signin.po.ts
@@ -18,8 +18,10 @@ export class OktaSignInPage {
       browser.waitForAngularEnabled(false);
     }
 
-    waitUntilVisible() {
-      browser.wait(ExpectedConditions.urlContains('/login'), 5000);
+    waitUntilVisible(issuer: string) {
+      // Check for a redirect to the Okta Hosted Login Page
+      const authorizeUrl = issuer.split('/oauth2')[0];
+      browser.wait(ExpectedConditions.urlContains(authorizeUrl), 5000);
     }
 
     getUsernameField() {

--- a/packages/okta-angular/test/e2e/harness/e2e/page-objects/okta-signin.po.ts
+++ b/packages/okta-angular/test/e2e/harness/e2e/page-objects/okta-signin.po.ts
@@ -20,8 +20,8 @@ export class OktaSignInPage {
 
     waitUntilVisible(issuer: string) {
       // Check for a redirect to the Okta Hosted Login Page
-      const authorizeUrl = issuer.split('/oauth2')[0];
-      browser.wait(ExpectedConditions.urlContains(authorizeUrl), 5000);
+      const baseUrl = issuer.split('/oauth2')[0];
+      browser.wait(ExpectedConditions.urlContains(baseUrl), 5000);
     }
 
     getUsernameField() {


### PR DESCRIPTION
Fixes a flaky test where we were checking for `/login` in the URL path instead of the domain name change.