### PR TITLE
:seedling: Make response_type configurable

### DIFF
--- a/packages/okta-vue/README.md
+++ b/packages/okta-vue/README.md
@@ -1,17 +1,22 @@
 # Okta Vue SDK
+
 The Okta Vue SDK is a wrapper around the [Okta Auth SDK](https://github.com/okta/okta-auth-js), which builds on top of Okta's [OpenID Connect API](https://developer.okta.com/docs/api/resources/oidc.html).
 
 This library currently supports:
-  - [OAuth 2.0 Implicit Flow](https://tools.ietf.org/html/rfc6749#section-1.3.2)
+
+- [OAuth 2.0 Implicit Flow](https://tools.ietf.org/html/rfc6749#section-1.3.2)
 
 ## Getting Started
-* If you do not already have a **Developer Edition Account**, you can create one at [https://developer.okta.com/signup/](https://developer.okta.com/signup/).
-* If you don't have a Vue app, or are new to Vue, please start with the [Vue CLI](https://github.com/vuejs/vue-cli) guide. It will walk you through the creation of a Vue app, creating [routers](https://router.vuejs.org/en/essentials/getting-started.html), and other application development essentials.
+
+- If you do not already have a **Developer Edition Account**, you can create one at [https://developer.okta.com/signup/](https://developer.okta.com/signup/).
+- If you don't have a Vue app, or are new to Vue, please start with the [Vue CLI](https://github.com/vuejs/vue-cli) guide. It will walk you through the creation of a Vue app, creating [routers](https://router.vuejs.org/en/essentials/getting-started.html), and other application development essentials.
 
 ### Add an OpenID Connect Client in Okta
+
 In Okta, applications are OpenID Connect clients that can use Okta Authorization servers to authenticate users.  Your Okta Org already has a default authorization server, so you just need to create an OIDC client that will use it.
-* Log into the Okta Developer Dashboard, click **Applications** > **Add Application**.
-* Choose **Single Page App (SPA)** as the platform, then submit the form the default values, which should look like this:
+
+- Log into the Okta Developer Dashboard, click **Applications** > **Add Application**.
+- Choose **Single Page App (SPA)** as the platform, then submit the form the default values, which should look like this:
 
 | Setting             | Value                                          |
 | ------------------- | ---------------------------------------------- |
@@ -27,7 +32,6 @@ After you have created the application there are two more values you will need t
 | Client ID     | In the applications list, or on the "General" tab of a specific application.   |
 | Org URL       | On the home screen of the developer dashboard, in the upper right.             |
 
-
 These values will be used in your Vue application to setup the OpenID Connect flow with Okta.
 
 ## Installation
@@ -39,6 +43,7 @@ npm install --save @okta/okta-vue
 ```
 
 ### Configuration
+
 You will need the values from the OIDC client that you created in the previous step to instantiate the middleware. You will also need to know your Okta Org URL, which you can see on the home page of the Okta Developer console.
 
 In your application's [vue-router](https://router.vuejs.org/en/essentials/getting-started.html) configuration, import the `@okta/okta-vue` plugin and pass it your OpenID Connect client information:
@@ -58,6 +63,7 @@ Vue.use(Auth, {
 ```
 
 ### Use the Callback Handler
+
 In order to handle the redirect back from Okta, you need to capture the token values from the URL. You'll use `/implicit/callback` as the callback URL, and use the default `Auth.handleCallback()` component included.
 
 ```typescript
@@ -74,6 +80,7 @@ const router = new Router({
 ```
 
 ### Add a Protected Route
+
 Routes are protected by the `authRedirectGuard`, which verifies there is a valid `accessToken` or `idToken` stored. To ensure the user has been authenticated before accessing your route, add the `requiresAuth` metadata:
 
 ```typescript
@@ -99,6 +106,7 @@ router.beforeEach(Vue.prototype.$auth.authRedirectGuard())
 If a user does not have a valid session, they will be redirected to the Okta Login Page for authentication. Once authenticated, they will be redirected back to your application's **protected** page.
 
 ### Show Login and Logout Buttons
+
 In the relevant location in your application, you will want to provide `Login` and `Logout` buttons for the user. You can show/hide the correct button by using the `$auth.isAuthenticated()` method. For example:
 
 ```typescript
@@ -145,6 +153,7 @@ export default {
 ```
 
 ### Use the Access Token
+
 When your users are authenticated, your Vue application has an access token that was issued by your Okta Authorization server. You can use this token to authenticate requests for resources on your server or API. As a hypothetical example, let's say you have an API that provides messages for a user. You could create a `MessageList` component that gets the access token and uses it to make an authenticated request to your server.
 
 Here is what the Vue component could look like for this hypothentical example using [axios](https://github.com/axios/axios):
@@ -184,6 +193,7 @@ export default {
 ```
 
 ### Using a custom login-page
+
 The `okta-vue` SDK supports the session token redirect flow for custom login pages. For more information, [see the basic Okta Sign-in Widget functionality](https://github.com/okta/okta-signin-widget#new-oktasigninconfig).
 
 To handle the session-token redirect flow, you can create your own navigation guard using the `requiresAuth` meta param:
@@ -202,17 +212,21 @@ router.beforeEach((from, to, next) {
 ```
 
 ## Reference
+
 ### `$auth`
 
 `$auth` is the top-most component of okta-vue. This is where most of the configuration is provided.
 
 #### Configuration Options
-  - `issuer` **(required)**: The OpenID Connect `issuer`
-  - `client_id` **(required)**: The OpenID Connect `client_id`
-  - `redirect_uri` **(required)**: Where the callback is hosted
-  - `scope` *(optional)*: Reserved or custom claims to be returned in the tokens
+
+- `issuer` **(required)**: The OpenID Connect `issuer`
+- `client_id` **(required)**: The OpenID Connect `client_id`
+- `redirect_uri` **(required)**: Where the callback is hosted
+- `scope` *(optional)*: Reserved or custom claims to be returned in the tokens
+- `response_type` *(optional)*: Desired token grant types
 
 #### `$auth.loginRedirect`
+
 Performs a full page redirect to Okta based on the initial configuration.  If you have an Okta `sessionToken`, you can bypass the full-page redirect by passing in this token. This is recommended when using the [Okta Sign-In Widget](https://github.com/okta/okta-signin-widget). Simply pass in a `sessionToken` into the `loginRedirect` method follows:
 
 ```typescript
@@ -224,21 +238,27 @@ this.$auth.loginRedirect({
 > Note: For information on obtaining a `sessionToken` using the [Okta Sign-In Widget](https://github.com/okta/okta-signin-widget), please see the [`renderEl()` example](https://github.com/okta/okta-signin-widget#rendereloptions-success-error).
 
 #### `$auth.isAuthenticated`
+
 Returns `true` if there is a valid access token or ID token.
 
 #### `$auth.getAccessToken`
+
 Returns the access token from storage (if it exists).
 
 #### `$auth.getIdToken`
+
 Returns the ID token from storage (if it exists).
 
 #### `$auth.getUser`
+
 Returns the result of the OpenID Connect `/userinfo` endpoint if an access token exists.
 
 #### `$auth.handleAuthentication`
+
 Parses the tokens returned as hash fragments in the OAuth 2.0 Redirect URI.
 
 ## Development
+
 1. Clone the repo:
     - `git clone git@github.com:okta/okta-oidc-js.git`
 2. Navigate into the `okta-vue` package:

--- a/packages/okta-vue/src/Auth.js
+++ b/packages/okta-vue/src/Auth.js
@@ -15,7 +15,7 @@ function install (Vue, options) {
   Vue.prototype.$auth = {
     loginRedirect (additionalParams) {
       return oktaAuth.token.getWithRedirect({
-        responseType: ['id_token', 'token'],
+        responseType: authConfig.response_type,
         scopes: authConfig.scope.split(' '),
         ...additionalParams
       })
@@ -82,6 +82,9 @@ const initConfig = auth => {
   if (!auth.redirect_uri) missing.push('redirect_uri')
   if (!auth.scope) auth.scope = 'openid'
   if (missing.length) throw new Error(`${missing.join(', ')} must be defined`)
+
+  // Use space separated response_type or default value
+  auth.response_type = (auth.response_type || 'id_token token').split(' ')
   return auth
 }
 

--- a/packages/okta-vue/src/Auth.spec.js
+++ b/packages/okta-vue/src/Auth.spec.js
@@ -35,12 +35,24 @@ describe('Auth', () => {
     localVue.use(Auth, {
       issuer: '1',
       client_id: '2',
+      redirect_uri: '3'
+    })
+    localVue.prototype.$auth.loginRedirect()
+    const mockCallValues = mockAuthJsInstance.token.getWithRedirect.mock.calls[0][0]
+    expect(mockCallValues.responseType).toEqual(expect.arrayContaining(['id_token', 'token']))
+    expect(mockCallValues.scopes).toEqual(expect.arrayContaining(['openid']))
+  })
+  test('sets the right scope and response_type overrides when redirecting to Okta', () => {
+    const localVue = createLocalVue()
+    localVue.use(Auth, {
+      issuer: '1',
+      client_id: '2',
       redirect_uri: '3',
       scope: 'foo bar',
       response_type: 'token'
     })
     localVue.prototype.$auth.loginRedirect()
-    const mockCallValues = mockAuthJsInstance.token.getWithRedirect.mock.calls[0][0]
+    const mockCallValues = mockAuthJsInstance.token.getWithRedirect.mock.calls[1][0]
     expect(mockCallValues.responseType).toEqual(expect.arrayContaining(['token']))
     expect(mockCallValues.scopes).toEqual(expect.arrayContaining(['foo', 'bar']))
   })

--- a/packages/okta-vue/src/Auth.spec.js
+++ b/packages/okta-vue/src/Auth.spec.js
@@ -11,17 +11,28 @@ AuthJS.mockImplementation(() => {
   return mockAuthJsInstance
 })
 
+const localVue = createLocalVue()
+
 describe('Auth', () => {
   test('is a Vue plugin', () => {
     expect(Auth.install).toBeTruthy()
   })
   test('sets the right user agent on AuthJS', () => {
     const expectedUserAgent = `${pkg.name}/${pkg.version} foo`
-    createLocalVue().use(Auth, {
+    localVue.use(Auth, {
       issuer: '1',
       client_id: '2',
       redirect_uri: '3'
     })
     expect(mockAuthJsInstance.userAgent).toMatch(expectedUserAgent)
+  })
+  test('sets the context for the $auth plugin', () => {
+    localVue.use(Auth, {
+      issuer: '1',
+      client_id: '2',
+      redirect_uri: '3',
+      response_type: 'a b'
+    })
+    expect(localVue.prototype.$auth).toBeDefined()
   })
 })


### PR DESCRIPTION
### Description
Allows the OAuth 2.0 `response_type` to be configurable for implicit flows.

**Important:** `code` isn't explicitly supported yet.

Resolves: #109 