### PR TITLE
:fire: Removes AuthJS getter

### DIFF
--- a/packages/okta-angular/src/okta/services/okta.service.ts
+++ b/packages/okta-angular/src/okta/services/okta.service.ts
@@ -74,13 +74,6 @@ export class OktaAuthService {
     }
 
     /**
-     * Returns the OktaAuth object to handle flows outside of this lib.
-     */
-    getOktaAuth(): OktaAuth {
-      return this.oktaAuth;
-    }
-
-    /**
      * Checks if there is an access token and id token
      */
     async isAuthenticated(): Promise<boolean> {

--- a/packages/okta-angular/test/e2e/harness/src/app/sessionToken-login.component.ts
+++ b/packages/okta-angular/test/e2e/harness/src/app/sessionToken-login.component.ts
@@ -13,6 +13,8 @@
 import { Component } from '@angular/core';
 import { OktaAuthService } from '@okta/okta-angular';
 
+import { environment } from './../environments/environment';
+
 import OktaAuth from '@okta/okta-auth-js';
 
 @Component({
@@ -36,8 +38,9 @@ export class SessionTokenLoginComponent {
   oktaAuth: OktaAuth;
 
   constructor(private okta: OktaAuthService) {
+    const baseUrl = environment.ISSUER.split('/oauth2')[0];
     this.oktaAuth = new OktaAuth({
-      url: this.okta.getOktaAuth().options.url
+      url: baseUrl
     });
   }
 


### PR DESCRIPTION
BREAKING CHANGE

- Removes the ability to retrieve the imported AuthJS instance from within this library.