### PR TITLE
Updates getUser method

### DIFF
--- a/packages/okta-react/README.md
+++ b/packages/okta-react/README.md
@@ -265,7 +265,7 @@ export default App;
 
 * `auth.getUser()`
 
-  Returns the result of the userinfo endpoint if an access token exists.
+  Returns the result of the OpenID Connect `/userinfo` endpoint if an access token exists.
 
 * `auth.getIdToken()`
 

--- a/packages/okta-react/src/Auth.js
+++ b/packages/okta-react/src/Auth.js
@@ -58,7 +58,16 @@ export default class Auth {
 
   async getUser() {
     const accessToken = this._oktaAuth.tokenManager.get('accessToken');
-    return accessToken ? this._oktaAuth.token.getUserInfo(accessToken) : undefined;
+    const idToken = this._oktaAuth.tokenManager.get('idToken');
+    if (accessToken && idToken) {
+      const userinfo = await this._oktaAuth.token.getUserInfo(accessToken);
+      if (userinfo.sub === idToken.claims.sub) {
+        // Only return the userinfo response if subjects match to
+        // mitigate token substitution attacks
+        return userinfo
+      }
+    }
+    return idToken ? idToken.claims : undefined;
   }
 
   async getIdToken() {

--- a/packages/okta-react/test/e2e/harness/e2e/App.test.js
+++ b/packages/okta-react/test/e2e/harness/e2e/App.test.js
@@ -42,6 +42,12 @@ describe('React + Okta App', () => {
     protectedPage.waitUntilVisible();
     expect(protectedPage.getLogoutButton().isPresent()).toBeTruthy();
 
+    protectedPage.waitForElement('userinfo-container');
+    protectedPage.getUserInfo().getText()
+    .then(userInfo => {
+      expect(userInfo).toContain('email');
+    });
+
     // Logout
     protectedPage.getLogoutButton().click();
 

--- a/packages/okta-react/test/e2e/harness/e2e/page-objects/protected.po.js
+++ b/packages/okta-react/test/e2e/harness/e2e/page-objects/protected.po.js
@@ -18,11 +18,12 @@ export class ProtectedPage {
   }
 
   waitUntilVisible() {
-    browser.wait(ExpectedConditions.presenceOf(this.getHeader()), 5000);
+    browser.wait(ExpectedConditions.urlContains('/protected'), 5000);
   }
-  
-  getHeader() {
-    return element(by.tagName('h3'));
+
+  waitForElement(id) {
+    const el = element(by.id(id));
+    browser.wait(ExpectedConditions.presenceOf(el), 5000);
   }
 
   getLogoutButton() {
@@ -31,5 +32,9 @@ export class ProtectedPage {
 
   getLoginButton() {
     return element(by.id('login-button'));
+  }
+
+  getUserInfo() {
+    return element(by.id('userinfo-container'));
   }
 }

--- a/packages/okta-react/test/e2e/harness/protractor.conf.js
+++ b/packages/okta-react/test/e2e/harness/protractor.conf.js
@@ -20,7 +20,7 @@ exports.config = {
   capabilities: {
     'browserName': 'chrome',
     chromeOptions: {
-      args: ['--headless','--disable-gpu','--window-size=1600x1200', '--no-sandbox']
+      args: ['--headless', '--disable-gpu', '--window-size=1600x1200', '--no-sandbox']
     }
   },
   directConnect: true,

--- a/packages/okta-react/test/e2e/harness/src/Protected.js
+++ b/packages/okta-react/test/e2e/harness/src/Protected.js
@@ -10,6 +10,27 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import React from 'react';
+import React, { Component } from 'react';
+import { withAuth } from '@okta/okta-react';
 
-export default () => <h3>Protected</h3>;
+export default withAuth(class Protected extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { userinfo: null };
+  }
+
+  async componentDidMount() {
+    const claims = await this.props.auth.getUser();
+    const userinfo = JSON.stringify(claims, null, 4);
+    this.setState({ userinfo });
+  }
+
+  render() {
+    return (
+      <div>
+        <div> Protected! </div>
+        {this.state.userinfo && <pre id="userinfo-container"> {this.state.userinfo} </pre>}
+      </div>
+    );
+  }
+});


### PR DESCRIPTION
Adds a helper method to return a payload of user information, based on the available tokens.

This method considers the token substitution attack vector mentioned [here](http://openid.net/specs/openid-connect-core-1_0.html#TokenSubstitution), using the recommendations outlined in [OpenID Connect UserInfo response](http://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse).

- [x] If there is an `accessToken` and `idToken` ➡️ Return the most up-to-date record from the `/userinfo` endpoint.
- [x] If there is **no** `accessToken`, but an `idToken` is present ➡️ Decode the `idToken` payload.
