### PR TITLE
:seedling: Make login and logout redirect paths configurable

### DIFF
--- a/packages/okta-react/README.md
+++ b/packages/okta-react/README.md
@@ -275,13 +275,13 @@ export default App;
 
   Retrieves the access token from storage if it exists.
 
-* `auth.login()`
+* `auth.login(fromUri)`
 
-  Calls `onAuthRequired` or redirects to Okta if `onAuthRequired` is undefined.
+  Calls `onAuthRequired` or redirects to Okta if `onAuthRequired` is undefined. This method accepts a `fromUri` parameter to push the user to after successful authentication.
 
 * `auth.logout()`
 
-  Removes all the tokens and redirects to `/`.
+  Terminates the user's session in Okta and clears all stored tokens. Accepts an optional `uri` parameter to push the user to after logout.
 
 * `auth.redirect({sessionToken})`
 

--- a/packages/okta-react/src/Auth.js
+++ b/packages/okta-react/src/Auth.js
@@ -80,8 +80,8 @@ export default class Auth {
     return accessToken ? accessToken.accessToken : undefined;
   }
 
-  async login() {
-    localStorage.setItem('secureRouterReferrerPath', this._history.location.pathname);
+  async login(fromUri) {
+    localStorage.setItem('secureRouterReferrerPath', fromUri || this._history.location.pathname);
     if (this._config.onAuthRequired) {
       const auth = this;
       const history = this._history;
@@ -90,10 +90,10 @@ export default class Auth {
     await this.redirect();
   }
 
-  async logout() {
+  async logout(path) {
     this._oktaAuth.tokenManager.clear();
     await this._oktaAuth.signOut();
-    this._history.push('/');
+    this._history.push(path || '/');
   }
 
   async redirect({sessionToken} = {}) {

--- a/packages/okta-react/test/e2e/harness/e2e/App.test.js
+++ b/packages/okta-react/test/e2e/harness/e2e/App.test.js
@@ -68,11 +68,11 @@ describe('React + Okta App', () => {
       password: process.env.PASSWORD
     });
 
-    appPage.waitUntilVisible();
-    expect(appPage.getLogoutButton().isPresent()).toBeTruthy();
+    protectedPage.waitUntilVisible();
+    expect(protectedPage.getLogoutButton().isPresent()).toBeTruthy();
 
     // Logout
-    appPage.getLogoutButton().click();
+    protectedPage.getLogoutButton().click();
 
     appPage.waitUntilLoggedOut();
   });

--- a/packages/okta-react/test/e2e/harness/src/Home.js
+++ b/packages/okta-react/test/e2e/harness/src/Home.js
@@ -24,6 +24,9 @@ export default withAuth(class Home extends Component {
 
     this.checkAuthentication = this.checkAuthentication.bind(this);
     this.checkAuthentication();
+
+    this.login = this.login.bind(this);
+    this.logout = this.logout.bind(this);
   }
 
   async checkAuthentication() {
@@ -31,6 +34,14 @@ export default withAuth(class Home extends Component {
     if (authenticated !== this.state.authenticated) {
       this.setState({ authenticated });
     }
+  }
+
+  async login() {
+    this.props.auth.login('/protected');
+  }
+
+  async logout() {
+    this.props.auth.logout('/');
   }
 
   componentDidUpdate() {
@@ -43,8 +54,8 @@ export default withAuth(class Home extends Component {
     }
 
     const button = this.state.authenticated ?
-      <button id="logout-button" onClick={this.props.auth.logout}>Logout</button> :
-      <button id="login-button" onClick={this.props.auth.login}>Login</button>;
+      <button id="logout-button" onClick={this.logout}>Logout</button> :
+      <button id="login-button" onClick={this.login}>Login</button>;
 
     return (
       <div>


### PR DESCRIPTION
BREAKING CHANGE

- *Optional*: Specify the redirect path when calling the `login` method.
- *Optional*: Specify the redirect path when calling `logout`. (Defaults to `/`)