### PR TITLE
Added the ability to configure the token manager in Angular

### DIFF
--- a/packages/okta-angular/package.json
+++ b/packages/okta-angular/package.json
@@ -37,20 +37,21 @@
     "@okta/okta-auth-js": "^1.14.0"
   },
   "devDependencies": {
-    "@angular/common": "^4.4.3",
-    "@angular/compiler": "^4.4.3",
-    "@angular/compiler-cli": "^4.4.3",
-    "@angular/core": "^4.4.3",
-    "@angular/platform-browser": "^4.4.3",
-    "@angular/router": "^4.4.3",
-    "rxjs": "^5.4.3",
-    "typescript": "^2.5.2"
+    "@angular/cli": "^6.0.0",
+    "@angular/common": "^6.0.0",
+    "@angular/compiler": "^6.0.0",
+    "@angular/compiler-cli": "^6.0.0",
+    "@angular/core": "^6.0.0",
+    "@angular/platform-browser": "^6.0.0",
+    "@angular/router": "^6.0.0",
+    "rxjs": "^6.1.0",
+    "typescript": "^2.7.2"
   },
   "peerDependencies": {
-    "@angular/common": "^4.0.0",
-    "@angular/core": "^4.0.0",
-    "@angular/platform-browser": "^4.0.0",
-    "@angular/router": "^4.0.0",
-    "rxjs": "^5.4.3"
+    "@angular/common": "^6.0.0",
+    "@angular/core": "^6.0.0",
+    "@angular/platform-browser": "^6.0.0",
+    "@angular/router": "^6.0.0",
+    "rxjs": "^6.1.0"
   }
 }

--- a/packages/okta-angular/src/okta/models/okta-token-manager.config.ts
+++ b/packages/okta-angular/src/okta/models/okta-token-manager.config.ts
@@ -1,0 +1,10 @@
+/**
+ * @export
+ * @interface OktaTokenManagerConfig
+ *
+ * This interface represents the possible known properties for configuring the Okta token manager.
+ */
+export interface OktaTokenManagerConfig{
+    storage?: string;
+    autoRefresh?: boolean;
+}

--- a/packages/okta-angular/src/okta/models/okta.config.ts
+++ b/packages/okta-angular/src/okta/models/okta.config.ts
@@ -13,6 +13,7 @@
 import { InjectionToken } from '@angular/core';
 
 import { AuthRequiredFunction } from './auth-required-function';
+import { OktaTokenManagerConfig } from './okta-token-manager.config';
 
 export interface OktaConfig {
   issuer?: string;
@@ -21,6 +22,7 @@ export interface OktaConfig {
   scope?: string;
   responseType?: string;
   onAuthRequired?: AuthRequiredFunction;
+  tokenManager?: OktaTokenManagerConfig;
 }
 
 export const OKTA_CONFIG = new InjectionToken<OktaConfig>('okta.config.angular');

--- a/packages/okta-angular/src/okta/services/okta.service.ts
+++ b/packages/okta-angular/src/okta/services/okta.service.ts
@@ -22,8 +22,7 @@ import packageInfo from '../packageInfo';
  * Import the okta-auth-js library
  */
 import * as OktaAuth from '@okta/okta-auth-js';
-import { Observable } from 'rxjs/Observable';
-import { Observer } from 'rxjs/Observer';
+import { Observable, Observer } from 'rxjs';
 
 @Injectable()
 export class OktaAuthService {

--- a/packages/okta-angular/src/okta/services/okta.service.ts
+++ b/packages/okta-angular/src/okta/services/okta.service.ts
@@ -55,7 +55,8 @@ export class OktaAuthService {
         url: auth.issuer.split('/oauth2/')[0],
         clientId: auth.clientId,
         issuer: auth.issuer,
-        redirectUri: auth.redirectUri
+        redirectUri: auth.redirectUri,
+        tokenManager: auth.tokenManager
       });
 
       this.oktaAuth.userAgent = `${packageInfo.name}/${packageInfo.version} ${this.oktaAuth.userAgent}`;


### PR DESCRIPTION
This proposed change will add the ability to configure the okta-auth-js token manager in the Angular package. Given that okta-auth-js already has this ability to perform this configuration with all the proper default setting and error handling shouldn't have any breaking changes ([code reference](https://github.com/okta/okta-auth-js/blob/c4906a2eefc6b492b6cccb28ccc791c116c5e768/lib/TokenManager.js#L132-L179)). Also added a simple interface (OktaTokenManagerConfig) to highlight the current options available for configuring okta-auth-js token manager which used as an optional property in OktaConfig.