### PR TITLE
(react-native): Use full package name in user agent

### DIFF
--- a/packages/okta-react-native/__tests__/token-client-util.test.js
+++ b/packages/okta-react-native/__tests__/token-client-util.test.js
@@ -51,7 +51,7 @@ describe('TokenClientUtil', () => {
             headers: {
               'Accept': 'application/json',
               'Content-Type': 'application/json',
-              'X-Okta-User-Agent-Extended': `okta-react-native/${packageJson.version} ios/test-version ios-platform`,
+              'X-Okta-User-Agent-Extended': `@okta/okta-react-native/${packageJson.version} ios/test-version ios-platform`,
             }
           }
         }
@@ -69,7 +69,7 @@ describe('TokenClientUtil', () => {
             headers: {
               'Accept': 'application/json',
               'Content-Type': 'application/json',
-              'X-Okta-User-Agent-Extended': `okta-react-native/${packageJson.version} android/test-version android-platform`,
+              'X-Okta-User-Agent-Extended': `@okta/okta-react-native/${packageJson.version} android/test-version android-platform`,
             }
           }
         }

--- a/packages/okta-react-native/__tests__/token-client.test.js
+++ b/packages/okta-react-native/__tests__/token-client.test.js
@@ -244,7 +244,7 @@ describe('TokenClient', () => {
               'Accept': 'application/json',
               'Authorization': 'Bearer dummy_access_token',
               'Content-Type': 'application/json',
-              'X-Okta-User-Agent-Extended': `okta-react-native/${packageJson.version} ios/test-version ios-platform`,
+              'X-Okta-User-Agent-Extended': `@okta/okta-react-native/${packageJson.version} ios/test-version ios-platform`,
             }
           },
           res: {

--- a/packages/okta-react-native/src/token-client-util.js
+++ b/packages/okta-react-native/src/token-client-util.js
@@ -31,7 +31,7 @@ export async function request(url, options) {
   options.headers = Object.assign({
     'Accept': 'application/json',
     'Content-Type': 'application/json',
-    'X-Okta-User-Agent-Extended': `okta-react-native/${packageJson.version} ${Platform.OS}/${Platform.Version} ${deviceName || ''}`.trim()
+    'X-Okta-User-Agent-Extended': `${packageJson.name}/${packageJson.version} ${Platform.OS}/${Platform.Version} ${deviceName || ''}`.trim()
   }, options.headers);
   const resp = await fetch(url, options);
   let json;


### PR DESCRIPTION
This makes it standard with our other node-based front-end libs