### PR TITLE
fix[okta-react]: Retain search and hash on ImplicitCallback redirect

### DIFF
--- a/packages/okta-react/src/Auth.js
+++ b/packages/okta-react/src/Auth.js
@@ -81,7 +81,7 @@ export default class Auth {
   }
 
   async login(fromUri) {
-    localStorage.setItem('secureRouterReferrerPath', fromUri || this._history.location.pathname);
+    localStorage.setItem('secureRouterReferrerPath', JSON.stringify(fromUri ? { pathname: fromUri } : this._history.location));
     if (this._config.onAuthRequired) {
       const auth = this;
       const history = this._history;

--- a/packages/okta-react/src/ImplicitCallback.js
+++ b/packages/okta-react/src/ImplicitCallback.js
@@ -36,11 +36,11 @@ export default withAuth(class ImplicitCallback extends Component {
     }
 
     const referrerKey = 'secureRouterReferrerPath';
-    const pathname = localStorage.getItem(referrerKey) || '/';
+    const location = JSON.parse(localStorage.getItem(referrerKey) || '{ "pathname": "/" }');
     localStorage.removeItem(referrerKey);
 
     return this.state.authenticated ? 
-      <Redirect to={{ pathname }}/> :
+      <Redirect to={location}/> :
       <p>{this.state.error}</p>;
   }
 });

--- a/packages/okta-react/test/e2e/harness/e2e/App.test.js
+++ b/packages/okta-react/test/e2e/harness/e2e/App.test.js
@@ -68,11 +68,11 @@ describe('React + Okta App', () => {
       password: process.env.PASSWORD
     });
 
-    protectedPage.waitUntilVisible();
+    appPage.waitUntilVisible();
     expect(protectedPage.getLogoutButton().isPresent()).toBeTruthy();
 
     // Logout
-    protectedPage.getLogoutButton().click();
+    appPage.getLogoutButton().click();
 
     appPage.waitUntilLoggedOut();
   });

--- a/packages/okta-react/test/e2e/harness/e2e/page-objects/protected.po.js
+++ b/packages/okta-react/test/e2e/harness/e2e/page-objects/protected.po.js
@@ -14,11 +14,11 @@ import { browser, element, by, ExpectedConditions } from 'protractor';
 
 export class ProtectedPage {
   navigateTo() {
-    return browser.get('/protected');
+    return browser.get('/protected?foo=bar#baz');
   }
 
   waitUntilVisible() {
-    browser.wait(ExpectedConditions.urlContains('/protected'), 5000);
+    browser.wait(ExpectedConditions.urlContains('/protected?foo=bar#baz'), 5000);
   }
 
   waitForElement(id) {


### PR DESCRIPTION
This PR is based on #175 and closes #175 #174

This PR adds a test commit and runs the test in our travis environment.