### PR TITLE
Publish

### DIFF
--- a/packages/oidc-middleware/CHANGELOG.md
+++ b/packages/oidc-middleware/CHANGELOG.md
@@ -1,0 +1,9 @@
+# 0.1.3
+
+### Bug Fixes
+
+- Removed next() in ensureAuthenticated ([#224](https://github.com/okta/okta-oidc-js/issues/224)) ([592ec42](https://github.com/okta/okta-oidc-js/commit/592ec420a4afcf12cbae5d04774502820e326b98))
+
+### Other
+
+- Updating openid-client dependency ([#222](https://github.com/okta/okta-oidc-js/issues/222)) ([8047386](https://github.com/okta/okta-oidc-js/commit/8047386519ca34ac4b6674d7e6a9b0e60a95de06/))

--- a/packages/oidc-middleware/package.json
+++ b/packages/oidc-middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okta/oidc-middleware",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "OpenId Connect middleware for authorization code flows",
   "repository": "https://github.com/okta/okta-oidc-js",
   "homepage": "https://github.com/okta/okta-oidc-js/tree/master/packages/oidc-middleware",


### PR DESCRIPTION
- @okta/oidc-middleware@0.1.3

I'm trying a different approach with this publish PR. Instead of inlining the changelog in the PR description I am committing it to the repo, and will populate the release from the changelog file.  Te Bugs section of the changelog file was generated by [standard-version](https://github.com/conventional-changelog/standard-version) (I had to manually pull in the chore tag, not sure yet how to have it do that automatically)