### PR TITLE
Okta-Vue: Catch error on parsing URI for Access Token 

### DIFF
--- a/packages/okta-vue/src/components/ImplicitCallback.vue
+++ b/packages/okta-vue/src/components/ImplicitCallback.vue
@@ -2,10 +2,15 @@
 export default {
   name: 'ImplicitCallback',
   async beforeMount () {
-    await this.$auth.handleAuthentication()
-    this.$router.replace({
-      path: this.$auth.getFromUri()
-    })
+    try {
+      await this.$auth.handleAuthentication()
+      this.$router.replace({
+        path: this.$auth.getFromUri()
+      })
+    } catch (error) {
+      console.warn(error);
+      this.$router.replace('/');
+    }
   },
   render () {}
 }


### PR DESCRIPTION
When the URI parsing doesn't work it throws an error and stays on a blank redirect page. This PR will console warn the error but redirect user to the root in order to not stop user experience.