### PR TITLE
[WIP don't merge] feat[okta-vue]: Add authentication error handler

### DIFF
--- a/packages/okta-vue/src/Auth.js
+++ b/packages/okta-vue/src/Auth.js
@@ -73,6 +73,7 @@ function install (Vue, options) {
       }
     }
   }
+  Vue.prototype.$auth.onAuthenticationError = authConfig.onAuthenticationError
 }
 
 function handleCallback () { return ImplicitCallback }

--- a/packages/okta-vue/src/components/ImplicitCallback.vue
+++ b/packages/okta-vue/src/components/ImplicitCallback.vue
@@ -1,12 +1,31 @@
 <script>
 export default {
   name: 'ImplicitCallback',
-  async beforeMount () {
-    await this.$auth.handleAuthentication()
-    this.$router.replace({
-      path: this.$auth.getFromUri()
-    })
+  data: () => ({
+    error_message: '',
+    error: false,
+  }),
+  async beforeMount() {
+    try {
+      await this.$auth.handleAuthentication();
+      this.$router.replace({
+        path: this.$auth.getFromUri(),
+      });
+    } catch (e) {
+      const handler = this.$auth.onAuthenticationError;
+      if (handler) {
+        return handler.call(this, e);
+      }
+      // Display error message on this callback view
+      this.error_message = e.message;
+      this.error = true;
+    }
   },
-  render () {}
-}
+  render(createElement) {
+    if (this.error) {
+      return createElement('div', this.error_message);
+    }
+    return createElement;
+  },
+};
 </script>


### PR DESCRIPTION
The default handler will show the error on the page, or the developer can provide their own handler as seen in the example below.

This PR doesn't yet have tests or README changes, this is for discussion on #225 and #234

```javascript
Vue.use(Auth, {
  issuer: sampleConfig.oidc.issuer,
  client_id: sampleConfig.oidc.clientId,
  redirect_uri: sampleConfig.oidc.redirectUri,
  scope: sampleConfig.oidc.scope,
  onAuthenticationError: function (error) {
    console.error(error)
    this.$router.replace('/')
  }
})

```