### PR TITLE
Add tokenManager to OktaAuth [okta-vue]

### DIFF
--- a/packages/okta-vue/README.md
+++ b/packages/okta-vue/README.md
@@ -60,10 +60,12 @@ Vue.use(Auth, {
   issuer: 'https://{yourOktaDomain}.com/oauth2/default',
   client_id: '{client_id}',
   redirect_uri: 'http://localhost:{port}/implicit/callback',
-  scope: 'openid profile email'
+  scope: 'openid profile email',
+  tokenManager: {}
 })
 
 ```
+You can also configure the tokenManager behavior. The configuration available for this object is defined in [The Token Manager](https://github.com/okta/okta-auth-js#the-tokenmanager).
 
 ### Use the Callback Handler
 

--- a/packages/okta-vue/src/Auth.js
+++ b/packages/okta-vue/src/Auth.js
@@ -8,7 +8,8 @@ function install (Vue, options) {
     clientId: authConfig.client_id,
     issuer: authConfig.issuer,
     redirectUri: authConfig.redirect_uri,
-    url: authConfig.issuer.split('/oauth2/')[0]
+    url: authConfig.issuer.split('/oauth2/')[0],
+    tokenManager: authConfig.tokenManager || {}
   })
   oktaAuth.userAgent = `${packageInfo.name}/${packageInfo.version} ${oktaAuth.userAgent}`
 


### PR DESCRIPTION
**What does this PR do?**
Allows the developer to setup the tokenManager configuration, such as: storage, autoRefresh, and all the configurations accepted by TokenManager.

Currently, there is no config option to setup the tokenManager. The developer is forced to use the default ones.