### PR TITLE
Remove wrapping div from Security component's render method

### DIFF
--- a/packages/okta-react/src/Security.js
+++ b/packages/okta-react/src/Security.js
@@ -32,10 +32,6 @@ export default withRouter(class Security extends Component {
   }
 
   render() {
-    return (
-      <div>
-        {this.props.children}
-      </div> 
-    );
+    return this.props.children;
   }
 });


### PR DESCRIPTION
There's no need to throw an additional wrapping div around the children, especially not one without any class names. Just return the children.