### PR TITLE
fix: Updates for internal CI scripts

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -12,9 +12,6 @@ git reset --hard $SHA
 git config --global user.email "oktauploader@okta.com"
 git config --global user.name "oktauploader-okta"
 
-# Use newer, faster npm
-npm install -g npm@5.0.3
-
 # Install required dependencies
 npm install -g lerna
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export PATH="${PATH}:$(yarn global bin)"
+
 cd ${OKTA_HOME}/${REPO}
 
 # undo permissions change on scripts/publish.sh


### PR DESCRIPTION
The `setup.sh` script was failing to find globally installed NPM  modules.  Applying the workarounds we've used elsewhere.