### PR TITLE
fix(okta-service): Remove validation from service

### DIFF
--- a/packages/okta-angular/src/okta/models/okta.config.ts
+++ b/packages/okta-angular/src/okta/models/okta.config.ts
@@ -15,9 +15,9 @@ import { InjectionToken } from '@angular/core';
 import { AuthRequiredFunction } from './auth-required-function';
 
 export interface OktaConfig {
-  issuer?: string;
-  redirectUri?: string;
-  clientId?: string;
+  issuer: string;
+  redirectUri: string;
+  clientId: string;
   scope?: string;
   responseType?: string;
   onAuthRequired?: AuthRequiredFunction;


### PR DESCRIPTION
* Use TypeScript for validation by requiring clientId, issuer, and redirectUri

Fixes #176