### PR TITLE
Allow additional params to be passed in for login and redirect methods

### DIFF
--- a/packages/okta-react/README.md
+++ b/packages/okta-react/README.md
@@ -295,23 +295,29 @@ Retrieves the id token from storage if it exists.
 
 Retrieves the access token from storage if it exists.
 
-#### `auth.login(fromUri)`
+#### `auth.login(fromUri, additionalParams)`
 
-Calls `onAuthRequired` or redirects to Okta if `onAuthRequired` is undefined. This method accepts a `fromUri` parameter to push the user to after successful authentication.
+Calls `onAuthRequired` or redirects to Okta if `onAuthRequired` is undefined. This method accepts a `fromUri` parameter to push the user to after successful authentication, and an optional `additionalParams` object.
+
+For more information on `additionalParams`, see the [`auth.redirect`](#authredirectadditionalparams) method below.
 
 #### `auth.logout(uri)`
 
 Terminates the user's session in Okta and clears all stored tokens. Accepts an optional `uri` parameter to push the user to after logout.
 
-#### `auth.redirect({sessionToken})`
+#### `auth.redirect(additionalParams)`
 
-Performs a redirect to Okta with an optional `sessionToken`.
+Performs a full-page redirect to Okta with optional request parameters.
+
+The `additionalParams` are mapped to the [AuthJS OpenID Connect Options](https://github.com/okta/okta-auth-js#openid-connect-options). This will override any existing [configuration](#configuration-options). As an example, if you have an Okta `sessionToken`, you can bypass the full-page redirect by passing in this token. This is recommended when using the [Okta Sign-In Widget](https://github.com/okta/okta-signin-widget). Simply pass in a `sessionToken` into the `loginRedirect` method follows:
 
 ```typescript
 auth.redirect({
   sessionToken: '{sampleSessionToken}'
 });
 ```
+
+> Note: For information on obtaining a `sessionToken` using the [Okta Sign-In Widget](https://github.com/okta/okta-signin-widget), please see the [`renderEl()` example](https://github.com/okta/okta-signin-widget#rendereloptions-success-error).
 
 #### `auth.handleAuthentication()`
 

--- a/packages/okta-react/README.md
+++ b/packages/okta-react/README.md
@@ -309,7 +309,7 @@ Terminates the user's session in Okta and clears all stored tokens. Accepts an o
 
 Performs a full-page redirect to Okta with optional request parameters.
 
-The `additionalParams` are mapped to the [AuthJS OpenID Connect Options](https://github.com/okta/okta-auth-js#openid-connect-options). This will override any existing [configuration](#configuration-options). As an example, if you have an Okta `sessionToken`, you can bypass the full-page redirect by passing in this token. This is recommended when using the [Okta Sign-In Widget](https://github.com/okta/okta-signin-widget). Simply pass in a `sessionToken` into the `loginRedirect` method follows:
+The `additionalParams` are mapped to Okta's [`/authorize` request parameters](https://developer.okta.com/docs/api/resources/oidc#authorize). This will override any existing [configuration](#configuration-options). As an example, if you have an Okta `sessionToken`, you can bypass the full-page redirect by passing in this token. This is recommended when using the [Okta Sign-In Widget](https://github.com/okta/okta-signin-widget). Simply pass in a `sessionToken` into the `redirect` method as follows:
 
 ```typescript
 auth.redirect({

--- a/packages/okta-react/package-lock.json
+++ b/packages/okta-react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@okta/okta-react",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/okta-react/test/jest/auth.test.js
+++ b/packages/okta-react/test/jest/auth.test.js
@@ -68,7 +68,7 @@ describe('Auth component', () => {
       scopes: ['openid', 'email', 'profile']
     });
   });
-  test('can override the authorize request builder with config params', () => {
+  test('can override the authorize request builder scope with config params', () => {
     const auth = new Auth({
       issuer: 'https://foo/oauth2/default',
       scope: ['openid', 'foo']
@@ -77,6 +77,17 @@ describe('Auth component', () => {
     expect(mockAuthJsInstance.token.getWithRedirect).toHaveBeenCalledWith({
       responseType: ['id_token', 'token'],
       scopes: ['openid', 'foo']
+    });
+  });
+  test('can override the authorize request builder responseType with config params', () => {
+    const auth = new Auth({
+      issuer: 'https://foo/oauth2/default',
+      response_type: ['id_token']
+    });
+    auth.redirect();
+    expect(mockAuthJsInstance.token.getWithRedirect).toHaveBeenCalledWith({
+      responseType: ['id_token'],
+      scopes: ['openid', 'email', 'profile']
     });
   });
   test('can override the authorize request builder with redirect params', () => {

--- a/packages/okta-react/test/jest/auth.test.js
+++ b/packages/okta-react/test/jest/auth.test.js
@@ -32,6 +32,9 @@ const mockAuthJsInstance = {
   userAgent: 'okta-auth-js',
   tokenManager: {
     get: jest.fn().mockReturnValue(Promise.resolve(standardAccessTokenParsed))
+  },
+  token: {
+    getWithRedirect: jest.fn()
   }
 };
 
@@ -39,18 +42,73 @@ AuthJS.mockImplementation(() => {
   return mockAuthJsInstance
 });
 
-test('Auth component sets the right user agent on AuthJS', () => {
-  const auth = new Auth({
-    issuer: 'https://foo/oauth2/default'
+describe('Auth component', () => {
+  test('sets the right user agent on AuthJS', () => {
+    const auth = new Auth({
+      issuer: 'https://foo/oauth2/default'
+    });
+    const expectedUserAgent = `${pkg.name}/${pkg.version} okta-auth-js`;
+    expect(auth._oktaAuth.userAgent).toMatch(expectedUserAgent);
   });
-  const expectedUserAgent = `${pkg.name}/${pkg.version} okta-auth-js`;
-  expect(auth._oktaAuth.userAgent).toMatch(expectedUserAgent);
-});
-test('Auth component can retrieve an accessToken from the tokenManager', async (done) => {
-  const auth = new Auth({
-    issuer: 'https://foo/oauth2/default'
+  test('can retrieve an accessToken from the tokenManager', async (done) => {
+    const auth = new Auth({
+      issuer: 'https://foo/oauth2/default'
+    });
+    const accessToken = await auth.getAccessToken();
+    expect(accessToken).toBe(mockAccessToken);
+    done();
   });
-  const accessToken = await auth.getAccessToken();
-  expect(accessToken).toBe(mockAccessToken);
-  done();
+  test('builds the authorize request with correct params', () => {
+    const auth = new Auth({
+      issuer: 'https://foo/oauth2/default'
+    });
+    auth.redirect();
+    expect(mockAuthJsInstance.token.getWithRedirect).toHaveBeenCalledWith({
+      responseType: ['id_token', 'token'],
+      scopes: ['openid', 'email', 'profile']
+    });
+  });
+  test('can override the authorize request builder with config params', () => {
+    const auth = new Auth({
+      issuer: 'https://foo/oauth2/default',
+      scope: ['openid', 'foo']
+    });
+    auth.redirect();
+    expect(mockAuthJsInstance.token.getWithRedirect).toHaveBeenCalledWith({
+      responseType: ['id_token', 'token'],
+      scopes: ['openid', 'foo']
+    });
+  });
+  test('can override the authorize request builder with redirect params', () => {
+    const auth = new Auth({
+      issuer: 'https://foo/oauth2/default'
+    });
+    auth.redirect({scope: ['openid', 'foo']});
+    expect(mockAuthJsInstance.token.getWithRedirect).toHaveBeenCalledWith({
+      responseType: ['id_token', 'token'],
+      scopes: ['openid', 'foo']
+    });
+  });
+  test('can append the authorize request builder with additionalParams through auth.redirect', () => {
+    const auth = new Auth({
+      issuer: 'https://foo/oauth2/default'
+    });
+    auth.redirect({foo: 'bar'});
+    expect(mockAuthJsInstance.token.getWithRedirect).toHaveBeenCalledWith({
+      responseType: ['id_token', 'token'],
+      scopes: ['openid', 'email', 'profile'],
+      foo: 'bar'
+    });
+  });
+  test('can append the authorize request builder with additionalParams through auth.login', () => {
+    const auth = new Auth({
+      issuer: 'https://foo/oauth2/default'
+    });
+    auth.login({foo: 'bar'});
+    expect(mockAuthJsInstance.token.getWithRedirect).toHaveBeenCalledWith({
+      responseType: ['id_token', 'token'],
+      scopes: ['openid', 'email', 'profile'],
+      foo: 'bar'
+    });
+  });
 });


### PR DESCRIPTION
### Description

Allow additional parameters to be passed into the `login` and `redirect` methods. This allows developers to override and/or extend values in their configuration for additional [OAuth 2.0 and OpenID Connect request parameters](http://openid.net/specs/openid-connect-core-1_0.html#AuthRequest):
  - `idp`
  - `login_hint`
  - `state`
  - `sessionToken`

#### Usage

```javascript
// Pre-fill username to the primary auth form and redirect back to the root path
await auth.login('/', {
  login_hint: 'my-foo-user'
});

// Similarly
await auth.redirect({
  login_hint: 'my-foo-user'
});
```

### Resolves
- #261 