### PR TITLE
Allow the "exact" and additional misc params to be passed into SecureRouter

### DIFF
--- a/packages/okta-react/src/SecureRoute.js
+++ b/packages/okta-react/src/SecureRoute.js
@@ -78,10 +78,15 @@ class SecureRoute extends Component {
   }
 
   render() {
-    return <Route
-      path={this.props.path}
-      render={this.createRenderWrapper}
-    />;
+    return (
+      <Route
+        path={this.props.path}
+        exact={this.props.exact}
+        strict={this.props.strict}
+        sensitive={this.props.sensitive}
+        render={this.createRenderWrapper}
+      />
+    );
   }
 };
 

--- a/packages/okta-react/test/e2e/harness/e2e/App.test.js
+++ b/packages/okta-react/test/e2e/harness/e2e/App.test.js
@@ -31,7 +31,7 @@ describe('React + Okta App', () => {
   });
 
   it('should redirect to Okta for login when trying to access a protected page', () => {
-    protectedPage.navigateTo();
+    protectedPage.navigateTo('?state=bar#baz');
 
     oktaLoginPage.waitUntilVisible();
     oktaLoginPage.signIn({
@@ -39,7 +39,7 @@ describe('React + Okta App', () => {
       password: process.env.PASSWORD
     });
 
-    protectedPage.waitUntilVisible();
+    protectedPage.waitUntilVisible('?state=bar#baz');
     expect(protectedPage.getLogoutButton().isPresent()).toBeTruthy();
 
     protectedPage.waitForElement('userinfo-container');
@@ -94,5 +94,13 @@ describe('React + Okta App', () => {
     appPage.getLogoutButton().click();
 
     appPage.waitUntilLoggedOut();
+  });
+
+  it('should honor the "exact" route param by not triggering the secureRoute', () => {
+    protectedPage.navigateTo('/nested/');
+    protectedPage.waitUntilVisible('/nested');
+
+    // Assert the navigation guard wasn't triggered due to "exact" path
+    expect(appPage.getLoginButton().isPresent()).toBeTruthy();
   });
 });

--- a/packages/okta-react/test/e2e/harness/e2e/page-objects/protected.po.js
+++ b/packages/okta-react/test/e2e/harness/e2e/page-objects/protected.po.js
@@ -13,12 +13,12 @@
 import { browser, element, by, ExpectedConditions } from 'protractor';
 
 export class ProtectedPage {
-  navigateTo() {
-    return browser.get('/protected/foo?state=bar#baz  ');
+  navigateTo(path) {
+    return browser.get('/protected' + path);
   }
 
-  waitUntilVisible() {
-    browser.wait(ExpectedConditions.urlContains('/protected/foo?state=bar#baz'), 5000);
+  waitUntilVisible(path) {
+    browser.wait(ExpectedConditions.urlContains('/protected' + path), 5000);
   }
 
   waitForElement(id) {

--- a/packages/okta-react/test/e2e/harness/src/App.js
+++ b/packages/okta-react/test/e2e/harness/src/App.js
@@ -34,7 +34,7 @@ class App extends Component {
             <Route path='/' component={Home}/>
             <Route path='/login' component={CustomLogin}/>
             <Route path='/sessionToken-login' component={SessionTokenLogin}/>
-            <SecureRoute path='/protected' component={Protected}/>=
+            <SecureRoute exact path='/protected' component={Protected}/>
             <Route path='/implicit/callback' component={ImplicitCallback} />
           </Security>
         </Router>

--- a/packages/okta-react/test/jest/secureRoute.test.js
+++ b/packages/okta-react/test/jest/secureRoute.test.js
@@ -1,0 +1,117 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { MemoryRouter, Route } from 'react-router-dom';
+import SecureRoute from '../../src/SecureRoute';
+import Security from '../../src/Security';
+
+describe('<SecureRoute />', () => {
+  const mockProps = {
+    auth: {},
+  };
+
+  it('should accept a "path" prop and render a component', () => {
+    const wrapper = mount(
+      <MemoryRouter>
+        <Security {...mockProps}>
+          <SecureRoute
+            path='/'
+          />
+        </Security>
+      </MemoryRouter>
+    );
+    expect(wrapper.find(SecureRoute).props().path).toBe('/');
+  });
+  it('should accept an "exact" prop and render a component', () => {
+    const wrapper = mount(
+      <MemoryRouter>
+        <Security {...mockProps}>
+          <SecureRoute
+            exact={true}
+            path='/'
+          />
+        </Security>
+      </MemoryRouter>
+    );
+    expect(wrapper.find(SecureRoute).props().exact).toBe(true);
+  });
+  it('should not contain an "exact" prop and render a component', () => {
+    const wrapper = mount(
+      <MemoryRouter>
+        <Security {...mockProps}>
+          <SecureRoute
+            path='/'
+          />
+        </Security>
+      </MemoryRouter>
+    );
+    expect(wrapper.find(SecureRoute).props().exact).toBeUndefined();
+  });
+  it('should accept a "strict" prop and render a component', () => {
+    const wrapper = mount(
+      <MemoryRouter>
+        <Security {...mockProps}>
+          <SecureRoute
+            strict={true}
+            path='/'
+          />
+        </Security>
+      </MemoryRouter>
+    );
+    expect(wrapper.find(SecureRoute).props().strict).toBe(true);
+  });
+  it('should accept a "sensitive" prop and render a component', () => {
+    const wrapper = mount(
+      <MemoryRouter>
+        <Security {...mockProps}>
+          <SecureRoute
+            sensitive={true}
+            path='/'
+          />
+        </Security>
+      </MemoryRouter>
+    );
+    expect(wrapper.find(SecureRoute).props().sensitive).toBe(true);
+  });
+  it('should accept an "exact" prop and pass it to an internal Route', () => {
+    const wrapper = mount(
+      <MemoryRouter>
+        <Security {...mockProps}>
+          <SecureRoute
+            exact={true}
+            path='/'
+          />
+        </Security>
+      </MemoryRouter>
+    );
+    const secureRoute = wrapper.find(SecureRoute);
+    expect(secureRoute.find(Route).props().exact).toBe(true);
+  });
+  it('should accept a "strict" prop and pass it to an internal Route', () => {
+    const wrapper = mount(
+      <MemoryRouter>
+        <Security {...mockProps}>
+          <SecureRoute
+            strict={true}
+            path='/'
+          />
+        </Security>
+      </MemoryRouter>
+    );
+    const secureRoute = wrapper.find(SecureRoute);
+    expect(secureRoute.find(Route).props().strict).toBe(true);
+  });
+  it('should accept a "sensitive" prop and pass it to an internal Route', () => {
+    const wrapper = mount(
+      <MemoryRouter>
+        <Security {...mockProps}>
+          <SecureRoute
+            sensitive={true}
+            path='/'
+          />
+        </Security>
+      </MemoryRouter>
+    );
+    const secureRoute = wrapper.find(SecureRoute);
+    expect(secureRoute.find(Route).props().sensitive).toBe(true);
+  });
+});


### PR DESCRIPTION
### Description

This PR allows additional [`Route` parameters](https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/api/Route.md) (notably `exact`) to be passed directly into a `Route`.

#### Resolves
- #70 
