### PR TITLE
Add session helpers to @okta/react

### DIFF
--- a/packages/okta-react/src/Auth.js
+++ b/packages/okta-react/src/Auth.js
@@ -32,6 +32,9 @@ export default class Auth {
     this.isAuthenticated = this.isAuthenticated.bind(this);
     this.getUser = this.getUser.bind(this);
     this.getIdToken = this.getIdToken.bind(this);
+    this.isSessionActive = this.isSessionActive.bind(this);
+    this.getActiveSession = this.getActiveSession.bind(this);
+    this.refreshSession = this.refreshSession.bind(this);
     this.getAccessToken = this.getAccessToken.bind(this);
     this.login = this.login.bind(this);
     this.logout = this.logout.bind(this);
@@ -53,7 +56,7 @@ export default class Auth {
   async isAuthenticated() {
     // If there could be tokens in the url
     if (location && location.hash && containsAuthTokens.test(location.hash)) return null;
-    return !!(await this.getAccessToken()) || !!(await this.getIdToken());
+    return !!(await this.getActiveSession()) || !!(await this.getAccessToken()) || !!(await this.getIdToken());
   }
 
   async getUser() {
@@ -68,6 +71,19 @@ export default class Auth {
       }
     }
     return idToken ? idToken.claims : undefined;
+  }
+
+  async isSessionActive() {
+    return !!(await this._oktaAuth.session.exists());
+  }
+
+  async getActiveSession() {
+    const isSessionActive = await this.isSessionActive();
+    return isSessionActive ? await this._oktaAuth.session.get() : undefined;
+  }
+
+  async refreshSession() {
+    return await this._oktaAuth.session.refresh();
   }
 
   async getIdToken() {
@@ -87,7 +103,7 @@ export default class Auth {
     localStorage.setItem(
       'secureRouterReferrerPath',
       JSON.stringify(referrerPath)
-      );
+    );
     if (this._config.onAuthRequired) {
       const auth = this;
       const history = this._history;
@@ -119,6 +135,6 @@ export default class Auth {
 
     // return a promise that doesn't terminate so nothing
     // happens after setting window.location
-    return new Promise((resolve, reject) => {});
+    return new Promise((resolve, reject) => { });
   }
 };


### PR DESCRIPTION
Currently, the `isAuthenticated()` method does not check for existing / valid Okta sessions and only gets stored tokens from local storage. Current open issues related to this are https://github.com/okta/okta-oidc-js/issues/244, https://github.com/okta/okta-oidc-js/issues/266 and https://github.com/okta/okta-oidc-js/issues/282.

This PR just adds and expose `session` helpers from https://github.com/okta/okta-auth-js#session so the client can handle and refresh the session if needed (i.e. through an HOC).

The helpers that are added on the `auth` objects are:

- isSessionActive
- getActiveSession
- refreshSession

