### PR TITLE
fix[okta-react]: Fixes login_required error

### DIFF
--- a/packages/okta-react/src/Auth.js
+++ b/packages/okta-react/src/Auth.js
@@ -71,13 +71,27 @@ export default class Auth {
   }
 
   async getIdToken() {
-    const idToken = await this._oktaAuth.tokenManager.get('idToken');
-    return idToken ? idToken.idToken : undefined;
+    try {
+      const idToken = await this._oktaAuth.tokenManager.get('idToken');
+      return idToken.idToken;
+    } catch (err) {
+      // The user no longer has an existing SSO session in the browser.
+      // (OIDC error `login_required`)
+      // Ask the user to authenticate again.
+      return undefined;
+    }
   }
 
   async getAccessToken() {
-    const accessToken = await this._oktaAuth.tokenManager.get('accessToken');
-    return accessToken ? accessToken.accessToken : undefined;
+    try {
+      const accessToken = await this._oktaAuth.tokenManager.get('accessToken');
+      return accessToken.accessToken;
+    } catch (err) {
+      // The user no longer has an existing SSO session in the browser.
+      // (OIDC error `login_required`)
+      // Ask the user to authenticate again.
+      return undefined;
+    }
   }
 
   async login(fromUri, additionalParams) {


### PR DESCRIPTION
### Description

The TokenManager throws an error when tries to renew a token but Okta session is expired.
The SDK should capture that error in the getAccessToken and getIdToken functions and return undefined instead.
In this way, also the isAuthenticated function will return false, so the router can correctly redirect to a new login.

### Reviewers

@robertjd @jmelberg-okta @nbarbettini 