### PR TITLE
fix[okta-vue]: Fixes login_required error

### DIFF
--- a/packages/okta-vue/src/Auth.js
+++ b/packages/okta-vue/src/Auth.js
@@ -27,7 +27,7 @@ function install (Vue, options) {
       await oktaAuth.signOut()
     },
     async isAuthenticated () {
-      return !!(await oktaAuth.tokenManager.get('accessToken')) || !!(await oktaAuth.tokenManager.get('idToken'))
+      return !!(await this.getAccessToken()) || !!(await this.getIdToken())
     },
     async handleAuthentication () {
       const tokens = await oktaAuth.token.parseFromUrl()
@@ -42,12 +42,26 @@ function install (Vue, options) {
       return path
     },
     async getIdToken () {
-      const idToken = await oktaAuth.tokenManager.get('idToken')
-      return idToken ? idToken.idToken : undefined
+      try {
+        const idToken = await oktaAuth.tokenManager.get('idToken')
+        return idToken.idToken
+      } catch (err) {
+        // The user no longer has an existing SSO session in the browser.
+        // (OIDC error `login_required`)
+        // Ask the user to authenticate again.
+        return undefined
+      }
     },
     async getAccessToken () {
-      const accessToken = await oktaAuth.tokenManager.get('accessToken')
-      return accessToken ? accessToken.accessToken : undefined
+      try {
+        const accessToken = await oktaAuth.tokenManager.get('accessToken')
+        return accessToken.accessToken
+      } catch (err) {
+        // The user no longer has an existing SSO session in the browser.
+        // (OIDC error `login_required`)
+        // Ask the user to authenticate again.
+        return undefined
+      }
     },
     async getUser () {
       const accessToken = await oktaAuth.tokenManager.get('accessToken')


### PR DESCRIPTION
### Description

The TokenManager throws an error when tries to renew a token but Okta session is expired.
The SDK should capture that error in the getAccessToken and getIdToken functions and return undefined instead.
In this way, also the isAuthenticated function will return false, so the router can correctly redirect to a new login.

Also makes the isAuthenticated function to use the getAccessToken() and getIdToken() functions instead of using directly the tokenManager, like we do for the other SDKs.

### Reviewers

@robertjd @jmelberg-okta @nbarbettini 

### Additional Reviewers

@sirgalleto
