### PR TITLE
Build constancy improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ packageInfo.js
 packageInfo.ts
 coverage
 *.tgz
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
 - npm install
 
 before_install:
-- "npm install -g npm@5.6.0"
+- "npm install -g npm@6.2.0"
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start
 - sudo apt-get update

--- a/packages/oidc-middleware/package-lock.json
+++ b/packages/oidc-middleware/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@okta/oidc-middleware",
-  "version": "0.1.3",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1649,6 +1649,12 @@
       "requires": {
         "webidl-conversions": "^4.0.2"
       }
+    },
+    "dotenv": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
+      "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
+      "dev": true
     },
     "duplexer3": {
       "version": "0.1.4",

--- a/packages/oidc-middleware/package.json
+++ b/packages/oidc-middleware/package.json
@@ -37,6 +37,7 @@
     "uuid": "^3.1.0"
   },
   "devDependencies": {
+    "dotenv": "^5.0.1",
     "cross-env": "^5.1.1",
     "ejs": "^2.5.7",
     "express-session": "^1.15.5",

--- a/packages/oidc-middleware/test/e2e/util/constants.js
+++ b/packages/oidc-middleware/test/e2e/util/constants.js
@@ -9,6 +9,10 @@
  *
  * See the License for the specific language governing permissions and limitations under the License.
  */
+const path = require('path');
+const dotenv = require('dotenv');
+dotenv.config({path: path.join(require('os').homedir(), '.okta', 'testenv')});
+dotenv.config({path: path.join(__dirname, '..', '..', '..', '..', 'testenv')});
 
 const PORT = process.env.PORT || 8080;
 const BASE_URI = process.env.BASE_URI || `http://localhost:${PORT}`;


### PR DESCRIPTION
* CI now uses npm 6.2.0
* dotenv is uses to help run our ITs (same way the e2e tests work in the TCK)