### PR TITLE
Adds support to run the https mode of the TCK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ lerna-debug.log
 
 # Ignore TCK-related files in all folders
 okta-oidc-tck*
+tck-keystore.pem
 target
 packages/okta-vue/test/e2e/harness/config/dev.env.js
 
@@ -16,3 +17,4 @@ packageInfo.js
 packageInfo.ts
 coverage
 *.tgz
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,16 @@ addons:
       - oracle-java8-set-default
 
 script:
-- npm install
-- npm run bootstrap
+- yarn install
 - sh ./scripts/runTests.sh
 - bash ./scripts/snyk.sh
 
 install:
-- npm install
+- yarn install
 
 before_install:
-- "npm install -g npm@5.6.0"
+- curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.9.4
+- export PATH="$HOME/.yarn/bin:$PATH"
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start
 - sudo apt-get update

--- a/packages/jwt-verifier/test/integration-test/resource-server.js
+++ b/packages/jwt-verifier/test/integration-test/resource-server.js
@@ -14,10 +14,13 @@ const express = require('express');
 const OktaJwtVerifier = require('../../lib');
 var cors = require('cors');
 
+const ISSUER = process.env.ISSUER || 'http://localhost:9090/oauth2/default';
+const AUDIENCE = process.env.AUDIANCE || 'api://default';
+
 const oktaJwtVerifier = new OktaJwtVerifier({
-  issuer: 'http://localhost:9090/oauth2/default',
+  issuer: ISSUER,
   assertClaims: {
-    aud: 'api://default'
+    aud: AUDIENCE
   },
 });
 

--- a/packages/jwt-verifier/test/integration-test/resources/testRunner.yml
+++ b/packages/jwt-verifier/test/integration-test/resources/testRunner.yml
@@ -24,6 +24,6 @@ scenarios:
     command: node
     env:
       ISSUER: https://localhost:9999/oauth2/default
-      NODE_EXTRA_CA_CERTS: ../../tck-keystore.pem
+      NODE_EXTRA_CA_CERTS: ./tck-keystore.pem
     args:
     - test/integration-test/resource-server.js

--- a/packages/jwt-verifier/test/integration-test/resources/testRunner.yml
+++ b/packages/jwt-verifier/test/integration-test/resources/testRunner.yml
@@ -20,6 +20,10 @@ scenarios:
     ports:
       applicationPort: 8080
       mockPort: 9090
+      mockHttpsPort: 9999
     command: node
+    env:
+      ISSUER: https://localhost:9999/oauth2/default
+      NODE_EXTRA_CA_CERTS: ../../tck-keystore.pem
     args:
     - test/integration-test/resource-server.js

--- a/packages/jwt-verifier/tools/runIntegrationTests.sh
+++ b/packages/jwt-verifier/tools/runIntegrationTests.sh
@@ -1,4 +1,31 @@
 #!/bin/bash
 
-source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../../../scripts/tck.sh"
-runTck "./test/integration-test/resources/testRunner.yml" "target/cli-test-output" "./test/integration-test/resources/testng.xml"
+TCK_VERSION=0.4.0-SNAPSHOT
+TCK_JAR_URL="https://oss.sonatype.org/service/local/artifact/maven/redirect?r=public&g=com.okta.oidc.tck&a=okta-oidc-tck&v=${TCK_VERSION}&e=jar&c=shaded"
+TCK_FILE="./okta-oidc-tck-${TCK_VERSION}-shaded.jar"
+TCK_PEM="./tck-keystore.pem"
+
+test_runner_yml="./test/integration-test/resources/testRunner.yml"
+test_output_dir="target/cli-test-output"
+testng_xml="./test/integration-test/resources/testng.xml"
+
+echo "TCK_FILE:"
+ls "${TCK_FILE}" || curl "${TCK_JAR_URL}" -L -o "${TCK_FILE}"
+
+# extract TCK self signed cert
+unzip -p "${TCK_FILE}" BOOT-INF/classes/tck-keystore.pem > "${TCK_PEM}"
+
+mkdir -p target
+#JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000"
+java ${JAVA_OPTS} -Dconfig="${test_runner_yml}" -jar "${TCK_FILE}" -d "${test_output_dir}" "${testng_xml}"
+
+
+echo "----------------STATUS----------------";
+echo $?
+echo "----------------STATUS----------------";
+
+# TestNG returns an exit code of 2 if tests are skipped. We don't want to consider it as test failure.
+if [ $? == 2 ]
+then
+    exit 0
+fi

--- a/packages/jwt-verifier/tools/runIntegrationTests.sh
+++ b/packages/jwt-verifier/tools/runIntegrationTests.sh
@@ -1,14 +1,4 @@
 #!/bin/bash
 
-TCK_VERSION=0.2.2
-TCK_JAR="https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=com.okta.oidc.tck&a=okta-oidc-tck&v=${TCK_VERSION}-SNAPSHOT&e=jar&c=shaded"
-ls ./okta-oidc-tck-${TCK_VERSION}-SNAPSHOT-shaded.jar || curl $TCK_JAR -L -o okta-oidc-tck-${TCK_VERSION}-SNAPSHOT-shaded.jar
-
-mkdir -p target
-java -Dconfig=./test/integration-test/resources/testRunner.yml -cp ./okta-oidc-tck-${TCK_VERSION}-SNAPSHOT-shaded.jar org.testng.TestNG -d target/cli-test-output ./test/integration-test/resources/testng.xml
-
-# TestNG returns an exit code of 2 if tests are skipped. We don't want to consider it as test failure.
-if [ $? == 2 ]
-then
-    exit 0
-fi
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../../../scripts/tck.sh"
+runTck "./test/integration-test/resources/testRunner.yml" "target/cli-test-output" "./test/integration-test/resources/testng.xml"

--- a/packages/oidc-middleware/test/integration-test/resources/testRunner.yml
+++ b/packages/oidc-middleware/test/integration-test/resources/testRunner.yml
@@ -25,6 +25,6 @@ scenarios:
       ISSUER: https://localhost:9999/oauth2/default
       CLIENT_ID: OOICU812
       CLIENT_SECRET: VERY_SECRET
-      NODE_EXTRA_CA_CERTS: ../../tck-keystore.pem
+      NODE_EXTRA_CA_CERTS: ./tck-keystore.pem
     args:
     - test/integration-test/start-server.js

--- a/packages/oidc-middleware/test/integration-test/resources/testRunner.yml
+++ b/packages/oidc-middleware/test/integration-test/resources/testRunner.yml
@@ -18,6 +18,13 @@ scenarios:
     ports:
       applicationPort: 8080
       mockPort: 9090
+      mockHttpsPort: 9999
     command: node
+    env:
+      PORT: 8080
+      ISSUER: https://localhost:9999/oauth2/default
+      CLIENT_ID: OOICU812
+      CLIENT_SECRET: VERY_SECRET
+      NODE_EXTRA_CA_CERTS: ../../tck-keystore.pem
     args:
     - test/integration-test/start-server.js

--- a/packages/oidc-middleware/test/integration-test/start-server.js
+++ b/packages/oidc-middleware/test/integration-test/start-server.js
@@ -12,10 +12,5 @@
 
 const util = require('../e2e/util/util');
 
-let server = util.createDemoServer({
-  // Skip https validation for mocking Okta auth server responses
-  testing: {
-    disableHttpsCheck: true
-  }
-});
+let server = util.createDemoServer();
 server.start();

--- a/packages/oidc-middleware/tools/runIntegrationTests.sh
+++ b/packages/oidc-middleware/tools/runIntegrationTests.sh
@@ -1,19 +1,4 @@
 #!/bin/bash
 
-TCK_VERSION=0.2.2
-TCK_JAR="https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=com.okta.oidc.tck&a=okta-oidc-tck&v=${TCK_VERSION}-SNAPSHOT&e=jar&c=shaded"
-ls ./okta-oidc-tck-${TCK_VERSION}-SNAPSHOT-shaded.jar || curl $TCK_JAR -L -o okta-oidc-tck-${TCK_VERSION}-SNAPSHOT-shaded.jar
-
-export ISSUER=http://localhost:9090/oauth2/default
-export WEB_CLIENT_ID=OOICU812
-export CLIENT_SECRET=VERY_SECRET
-
-mkdir -p target
-java -cp ./test/integration-test/resources/:./okta-oidc-tck-${TCK_VERSION}-SNAPSHOT-shaded.jar org.testng.TestNG -d target/cli-test-output ./test/integration-test/resources/testng.xml
-
-# TestNG returns an exit code of 2 if tests are skipped. We don't want to consider it as test failure.
-
-if [ $? == 1 ]
-then
-    exit -1
-fi
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../../../scripts/tck.sh"
+runTck "./test/integration-test/resources/testRunner.yml" "target/cli-test-output" "./test/integration-test/resources/testng.xml"

--- a/packages/oidc-middleware/tools/runIntegrationTests.sh
+++ b/packages/oidc-middleware/tools/runIntegrationTests.sh
@@ -1,4 +1,33 @@
 #!/bin/bash
 
-source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../../../scripts/tck.sh"
-runTck "./test/integration-test/resources/testRunner.yml" "target/cli-test-output" "./test/integration-test/resources/testng.xml"
+TCK_VERSION=0.4.0-SNAPSHOT
+TCK_JAR_URL="https://oss.sonatype.org/service/local/artifact/maven/redirect?r=public&g=com.okta.oidc.tck&a=okta-oidc-tck&v=${TCK_VERSION}&e=jar&c=shaded"
+TCK_FILE="./okta-oidc-tck-${TCK_VERSION}-shaded.jar"
+TCK_PEM="./tck-keystore.pem"
+
+test_runner_yml="./test/integration-test/resources/testRunner.yml"
+test_output_dir="target/cli-test-output"
+testng_xml="./test/integration-test/resources/testng.xml"
+
+echo "TCK_FILE:"
+ls "${TCK_FILE}" || curl "${TCK_JAR_URL}" -L -o "${TCK_FILE}"
+
+# extract TCK self signed cert
+unzip -p "${TCK_FILE}" BOOT-INF/classes/tck-keystore.pem > "${TCK_PEM}"
+
+mkdir -p target
+#JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000"
+java ${JAVA_OPTS} -Dconfig="${test_runner_yml}" -jar "${TCK_FILE}" -d "${test_output_dir}" "${testng_xml}"
+
+
+echo "----------------STATUS----------------";
+echo $?
+echo "----------------STATUS----------------";
+
+# TestNG returns an exit code of 2 if tests are skipped. We don't want to consider it as test failure.
+if [ $? == 2 ]
+then
+    exit 0
+fi
+
+for file in ./target/node*; do echo "$file";  cat "$file"; done

--- a/scripts/runTests.sh
+++ b/scripts/runTests.sh
@@ -3,7 +3,8 @@
 for package in `ls $PWD/packages`;
 do
     cd $PWD/packages/$package
-    npm test
+    yarn install
+    yarn test
     if [ $? -ne 0 ]; then
         echo "------- [ERROR] Test failures in $package -------"
         exit 1

--- a/scripts/tck.sh
+++ b/scripts/tck.sh
@@ -6,7 +6,7 @@ RESOURCE_DIR="$( realpath $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.. )
 TCK_FILE="${RESOURCE_DIR}/okta-oidc-tck-${TCK_VERSION}-shaded.jar"
 TCK_PEM="${RESOURCE_DIR}/tck-keystore.pem"
 
-function runTck () {
+function runTck {
 
     test_runner_yml=$1 # ./test/integration-test/resources/testRunner.yml
     test_output_dir=$2 # target/cli-test-output
@@ -15,13 +15,13 @@ function runTck () {
     echo "TCK_FILE:"
     ls "${TCK_FILE}" || curl "${TCK_JAR_URL}" -L -o "${TCK_FILE}"
 
-    # extract TCK self signed cert    
+    # extract TCK self signed cert
     unzip -p "${TCK_FILE}" BOOT-INF/classes/tck-keystore.pem > "${TCK_PEM}"
-    
+
     mkdir -p target
     #JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000"
     java ${JAVA_OPTS} -Dconfig="${test_runner_yml}" -jar "${TCK_FILE}" -d "${test_output_dir}" "${testng_xml}"
-    
+
     # TestNG returns an exit code of 2 if tests are skipped. We don't want to consider it as test failure.
     if [ $? == 2 ]
     then

--- a/scripts/tck.sh
+++ b/scripts/tck.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+TCK_VERSION=0.4.0-SNAPSHOT
+TCK_JAR_URL="https://oss.sonatype.org/service/local/artifact/maven/redirect?r=public&g=com.okta.oidc.tck&a=okta-oidc-tck&v=${TCK_VERSION}&e=jar&c=shaded"
+RESOURCE_DIR="$( realpath $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.. )"
+TCK_FILE="${RESOURCE_DIR}/okta-oidc-tck-${TCK_VERSION}-shaded.jar"
+TCK_PEM="${RESOURCE_DIR}/tck-keystore.pem"
+
+function runTck () {
+
+    test_runner_yml=$1 # ./test/integration-test/resources/testRunner.yml
+    test_output_dir=$2 # target/cli-test-output
+    testng_xml=$3      # ./test/integration-test/resources/testng.xml
+
+    echo "TCK_FILE:"
+    ls "${TCK_FILE}" || curl "${TCK_JAR_URL}" -L -o "${TCK_FILE}"
+
+    # extract TCK self signed cert    
+    unzip -p "${TCK_FILE}" BOOT-INF/classes/tck-keystore.pem > "${TCK_PEM}"
+    
+    mkdir -p target
+    #JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000"
+    java ${JAVA_OPTS} -Dconfig="${test_runner_yml}" -jar "${TCK_FILE}" -d "${test_output_dir}" "${testng_xml}"
+    
+    # TestNG returns an exit code of 2 if tests are skipped. We don't want to consider it as test failure.
+    if [ $? == 2 ]
+    then
+        exit 0
+    fi
+}


### PR DESCRIPTION
Moved common TCK logic to scripts/tck.sh
The TCK uses a self signed cert, which is unpacked to `tck-keystore.pem` and added to the env via NODE_EXTRA_CA_CERTS


**NOTE:** CI will fail until okta/okta-oidc-tck#40 is merged