### PR TITLE
chore: Cleanup test scripts

### DIFF
--- a/packages/jwt-verifier/package.json
+++ b/packages/jwt-verifier/package.json
@@ -9,9 +9,9 @@
     "src"
   ],
   "scripts": {
-    "test": "yarn test:sanity && yarn test:integration",
-    "test:sanity": "jest test/spec",
-    "test:integration": "sh tools/runIntegrationTests.sh"
+    "test": "yarn test:unit && yarn test:integration",
+    "test:integration": "sh tools/runIntegrationTests.sh",
+    "test:unit": "jest test/spec"
   },
   "keywords": [
     "okta",

--- a/packages/okta-angular/README.md
+++ b/packages/okta-angular/README.md
@@ -292,12 +292,11 @@ See the [getting started](/README.md#getting-started) section for step-by-step i
 
 ## Commands
 
-| Command        | Description                        |
-| -------------- | ---------------------------------- |
-| `yarn start`   | Start the sample app using the SDK |
-| `yarn test`    | Run integration tests              |
-| `yarn lint`    | Run eslint linting tests           |
-| `yarn docs`    | Generate typedocs                  |
+| Command      | Description                        |
+|--------------|------------------------------------|
+| `yarn start` | Start the sample app using the SDK |
+| `yarn test`  | Run unit and integration tests     |
+| `yarn lint`  | Run eslint linting tests           |
 
 [ID Token Claims]: https://developer.okta.com/docs/api/resources/oidc#id-token-claims
 [UserInfo endpoint]: https://developer.okta.com/docs/api/resources/oidc#userinfo

--- a/packages/okta-angular/package.json
+++ b/packages/okta-angular/package.json
@@ -8,19 +8,18 @@
     "dist"
   ],
   "scripts": {
+    "build:dependencies": "yarn ngc && cd test/e2e/harness && yarn install",
     "build:package-info": "node ../../util/write-package-info.js . src/okta/packageInfo.ts",
+    "lint": "yarn --cwd test/e2e/harness/ lint",
+    "ngc": "./node_modules/.bin/ngc -p tsconfig.json",
     "pretest": "yarn build:dependencies",
     "prestart": "yarn build:dependencies",
     "prepublish": "yarn ngc",
     "prengc": "yarn build:package-info",
-    "ngc": "./node_modules/.bin/ngc -p tsconfig.json",
-    "test": "yarn lint && yarn test:e2e && yarn test:unit",
-    "test:unit": "yarn --cwd test/e2e/harness/ test",
-    "test:e2e": "yarn --cwd test/e2e/harness/ e2e",
     "start": "yarn --cwd test/e2e/harness/ start",
-    "docs": "typedoc --options typedoc.json --exclude '{**/*.spec.ts,**/test/**}' ./src/",
-    "lint": "yarn --cwd test/e2e/harness/ lint",
-    "build:dependencies": "yarn ngc && yarn pack && cd test/e2e/harness && yarn add file:../../../okta-okta-angular-v$npm_package_version.tgz && yarn install"
+    "test": "yarn lint && yarn test:e2e && yarn test:unit",
+    "test:e2e": "yarn --cwd test/e2e/harness/ e2e",
+    "test:unit": "yarn --cwd test/e2e/harness/ test"
   },
   "repository": "https://github.com/okta/okta-oidc-js",
   "homepage": "https://github.com/okta/okta-oidc-js/tree/master/packages/okta-angular",

--- a/packages/okta-angular/test/e2e/harness/package.json
+++ b/packages/okta-angular/test/e2e/harness/package.json
@@ -22,7 +22,7 @@
     "@angular/platform-browser": "^6.0.7",
     "@angular/platform-browser-dynamic": "^6.0.7",
     "@angular/router": "^6.0.7",
-    "@okta/okta-angular": "file:../../../okta-okta-angular-v1.0.4.tgz",
+    "@okta/okta-angular": "../../../",
     "core-js": "^2.4.1",
     "ejs": "^2.5.6",
     "rxjs": "^6.2.1",

--- a/packages/okta-react-native/package.json
+++ b/packages/okta-react-native/package.json
@@ -4,7 +4,8 @@
   "description": "React Native support for OpenID Connect",
   "main": "src/token-client.js",
   "scripts": {
-    "test": "jest --coverage --verbose --testPathPattern __tests__/.*.test.js"
+    "test": "yarn test:unit",
+    "test:unit": "jest --coverage --verbose --testPathPattern __tests__/.*.test.js"
   },
   "jest": {
     "browser": true,

--- a/packages/okta-react/.eslintrc.js
+++ b/packages/okta-react/.eslintrc.js
@@ -1,0 +1,24 @@
+// https://eslint.org/docs/user-guide/configuring
+
+module.exports = {
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended'
+  ],
+  parser: "babel-eslint",
+  plugins: [
+    "react"
+  ],
+  env: {
+    browser: true,
+    es6: true
+  },
+  rules: {
+    'react/prop-types': 0
+  },
+  settings: {
+    react: {
+      version: '15.0',
+    }
+  }
+};

--- a/packages/okta-react/README.md
+++ b/packages/okta-react/README.md
@@ -335,5 +335,5 @@ See the [getting started](/README.md#getting-started) section for step-by-step i
 | Command      | Description                        |
 |--------------|------------------------------------|
 | `yarn start` | Start the sample app using the SDK |
-| `yarn test`  | Run integration tests              |
+| `yarn test`  | Run unit and integration tests     |
 | `yarn lint`  | Run eslint linting tests           |

--- a/packages/okta-react/package.json
+++ b/packages/okta-react/package.json
@@ -7,14 +7,15 @@
     "build": "rimraf dist/ && yarn build:package-info && babel src -d dist",
     "build:harness": "yarn --cwd test/e2e/harness install",
     "build:package-info": "node ../../util/write-package-info.js . src/packageInfo.js",
-    "jest": "jest test/jest/",
-    "lint": "eslint src/**; exit 0",
+    "lint": "eslint src",
     "lint:watch": "esw -w lib/**",
     "prepublish": "yarn build",
     "prestart": "yarn build && yarn build:harness",
-    "start": "yarn --cwd test/e2e/harness start",
     "pretest": "yarn build && yarn build:harness",
-    "test": "yarn jest && yarn --cwd test/e2e/harness test"
+    "start": "yarn --cwd test/e2e/harness start",
+    "test": "yarn lint && yarn test:unit && yarn test:e2e",
+    "test:e2e": "yarn --cwd test/e2e/harness test",
+    "test:unit": "jest test/jest/"
   },
   "repository": {
     "type": "git",

--- a/packages/okta-react/src/Auth.js
+++ b/packages/okta-react/src/Auth.js
@@ -133,6 +133,7 @@ export default class Auth {
 
     // return a promise that doesn't terminate so nothing
     // happens after setting window.location
+    /* eslint-disable-next-line no-unused-vars */
     return new Promise((resolve, reject) => {});
   }
-};
+}

--- a/packages/okta-react/src/SecureRoute.js
+++ b/packages/okta-react/src/SecureRoute.js
@@ -22,6 +22,7 @@ class RenderWrapper extends Component {
     }
   }
 
+  /* eslint-disable-next-line react/no-deprecated */
   componentWillMount() {
     this.checkAuthentication();
   }
@@ -88,6 +89,6 @@ class SecureRoute extends Component {
       />
     );
   }
-};
+}
 
 export default withAuth(SecureRoute);

--- a/packages/okta-react/src/Security.js
+++ b/packages/okta-react/src/Security.js
@@ -38,6 +38,6 @@ class Security extends Component {
       </div>
     );
   }
-};
+}
 
 export default withRouter(Security);

--- a/packages/okta-react/test/e2e/harness/package.json
+++ b/packages/okta-react/test/e2e/harness/package.json
@@ -27,7 +27,7 @@
     "build:test": "rimraf e2e/dist && babel e2e/ -d e2e/dist",
     "kill:port": "kill -9 $(lsof -t -i:8080 -sTCP:LISTEN) || true",
     "pretest": "yarn kill:port && ./node_modules/.bin/webdriver-manager update --gecko false && yarn build:test",
-    "wait:server": "yarn start & ./node_modules/.bin/wait-on http://localhost:8080",
+    "wait:server": "BROWSER=none yarn start & ./node_modules/.bin/wait-on http://localhost:8080",
     "test": "yarn build && yarn wait:server && yarn protractor",
     "eject": "react-scripts eject",
     "protractor": "babel-node ./node_modules/.bin/protractor protractor.conf.js"

--- a/packages/okta-vue/package.json
+++ b/packages/okta-vue/package.json
@@ -8,18 +8,19 @@
     "src"
   ],
   "scripts": {
-    "prebuild": "yarn build:package-info",
-    "prestart": "yarn build && yarn build:harness",
-    "kill:port": "kill -9 $(lsof -t -i:8080 -sTCP:LISTEN) || true",
-    "pretest": "yarn kill:port && yarn build && yarn build:harness",
-    "prepublish": "yarn build",
-    "jest": "jest src/",
-    "test": "yarn lint && yarn jest && yarn --cwd test/e2e/harness/ test",
-    "start": "yarn --cwd test/e2e/harness/ start",
     "build": "rimraf dist/ && cross-env NODE_ENV=production webpack --config webpack.config.js --output-library-target=umd -p",
     "build:harness": "yarn --cwd test/e2e/harness install",
     "build:package-info": "node ../../util/write-package-info.js . src/packageInfo.js",
-    "lint": "eslint --ext .js,.vue src"
+    "kill:port": "kill -9 $(lsof -t -i:8080 -sTCP:LISTEN) || true",
+    "lint": "eslint --ext .js,.vue src",
+    "prebuild": "yarn build:package-info",
+    "prestart": "yarn build && yarn build:harness",
+    "pretest": "yarn kill:port && yarn build && yarn build:harness",
+    "prepublish": "yarn build",
+    "start": "yarn --cwd test/e2e/harness/ start",
+    "test": "yarn lint && yarn test:unit && yarn test:e2e",
+    "test:e2e": "yarn --cwd test/e2e/harness/ test",
+    "test:unit": "jest src/"
   },
   "jest": {
     "moduleFileExtensions": [


### PR DESCRIPTION
### Description

This PR unifies the `package.json` test script names for every package. This will provide developers to easily call one of the following:

```bash
# Run end-to-end tests
# Applies to Angular, React, Vue, and oidc-middleware
yarn test:e2e

# Run integration tests using WireShark
# Applies to jwt-verifier and oidc-middleware
yarn test:integration

# Run unit tests
# Applies to all packages
yarn test:unit

# Run entire test suite
# Applies to all packages
yarn test
```

This PR is broken into the following commits:
  - [`ab78894`](https://github.com/okta/okta-oidc-js/commit/ab78894068d822020c3ba0c24633baff7fbae47f) - Adds eslint to `yarn test` for React package.
  - [`4189e59`](https://github.com/okta/okta-oidc-js/commit/4189e59ca422e20a8d153e2f433a452c35456347) - Removed `yarn pack` and file install from test-harness in Angular package.
  - [`f202fef`](https://github.com/okta/okta-oidc-js/commit/f202feff036a6376af5ca56501c57a284f5de7d9) - Unify remaining package test scripts into format noted above.

#### Reviewers
- @manueltanzi-okta 
- @vijetmahabaleshwar-okta