### PR TITLE
fix[configuration-validation]: Use babel to compile for IE 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log
 yarn-debug.log*
 yarn-error.log*
 package-lock.json
+dist
 
 # Ignore TCK-related files in all folders
 okta-oidc-tck*

--- a/packages/configuration-validation/.babelrc
+++ b/packages/configuration-validation/.babelrc
@@ -1,0 +1,11 @@
+{
+  "presets": [
+    [
+      "env", {
+        "targets": {
+          "browsers": [ "> 0.1%", "not ie < 11" ]
+        }
+      }
+    ]
+  ]
+}

--- a/packages/configuration-validation/package.json
+++ b/packages/configuration-validation/package.json
@@ -1,13 +1,16 @@
 {
   "name": "@okta/configuration-validation",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Configuration validation support for Okta JavaScript SDKs",
-  "main": "src/lib.js",
+  "main": "./dist/lib.js",
   "files": [
+    "dist",
     "src"
   ],
   "scripts": {
+    "build": "babel src -d dist",
     "lint": "eslint .",
+    "prepare": "yarn build",
     "test": "yarn lint && yarn test:unit",
     "test:unit": "jest test/"
   },
@@ -29,7 +32,8 @@
   },
   "homepage": "https://github.com/okta/okta-oidc-js#readme",
   "devDependencies": {
-    "jest": "^23.6.0",
-    "eslint": "^4.7.1"
+    "babel-cli": "^6.26.0",
+    "eslint": "^4.7.1",
+    "jest": "^23.6.0"
   }
 }


### PR DESCRIPTION
## Description

Use babel to compile `@okta/configuration-validation` library for IE 11 support.

## PR Checklist

- [x] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [x] Build related changes