### PR TITLE
Add types for TypeScript from @types/okta__okta-vue

### DIFF
--- a/packages/okta-vue/index.d.ts
+++ b/packages/okta-vue/index.d.ts
@@ -1,0 +1,45 @@
+import { PluginFunction, VueConstructor } from 'vue';
+import { NavigationGuard } from 'vue-router';
+
+declare namespace OktaVuePlugin {
+  interface OktaVueOptions {
+    issuer: string;
+    client_id: string;
+    redirect_uri: string;
+    scope?: string;
+    response_type?: string;
+  }
+
+  interface OktaOpenIDOptions {
+    sessionToken?: string;
+    responseMode?: string;
+    responseType?: string | string[];
+    scopes?: string[];
+    state?: string;
+    nonce?: string;
+  }
+
+  function install(vm: VueConstructor, options: OktaVueOptions): PluginFunction<VueConstructor>;
+
+  function handleCallback(): VueConstructor;
+}
+
+declare function OktaVuePlugin(): PluginFunction<VueConstructor>;
+
+export default OktaVuePlugin;
+
+declare module 'vue/types/vue' {
+  interface Vue {
+    $auth: {
+      loginRedirect(fromUri?: string, additionalParams?: OktaVuePlugin.OktaOpenIDOptions): void;
+      logout(): Promise<void>;
+      isAuthenticated(): Promise<boolean>;
+      handleAuthentication(): Promise<void>;
+      getFromUri(): string;
+      getIdToken(): Promise<string>;
+      getAccessToken(): Promise<string>;
+      getUser(): Promise<any>;
+      authRedirectGuard(): Promise<NavigationGuard>;
+    };
+  }
+}


### PR DESCRIPTION
Fixes #352.

**NOTE:** This PR does not modify the build to include the types in the final distribution. Any advice on how to do that would be great!

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?

To create a Vue application with TypeScript, you have to use a 3rd party's type definitions.

Issue Number: #352

## What is the new behavior?

Developers don't have to install a 3rd party library to use TypeScript and Okta's Vue SDK.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

Sample repo that uses 3rd party types: https://github.com/oktadeveloper/spring-boot-vue-example/tree/okta

## Reviewers

@robertjd @jmelberg-okta 