### PR TITLE
Fixes the flaky test in okta-angular

### DIFF
--- a/packages/okta-angular/test/e2e/harness/e2e/app.e2e-spec.ts
+++ b/packages/okta-angular/test/e2e/harness/e2e/app.e2e-spec.ts
@@ -49,6 +49,7 @@ describe('Angular + Okta App', () => {
     expect(protectedPage.getLogoutButton().isPresent()).toBeTruthy();
 
     // Verify the user object was returned
+    protectedPage.waitForElement('userinfo-container');
     protectedPage.getUserInfo().getText()
     .then(userInfo => {
       expect(userInfo).toContain('email');


### PR DESCRIPTION
The e2e test that expects a certain text to be present fails intermittently.
I have added a wait for element visible to fix the flakiness. 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

