### PR TITLE
Update oidcUtil to allow a callback without userinfo

### DIFF
--- a/packages/oidc-middleware/src/oidcUtil.js
+++ b/packages/oidc-middleware/src/oidcUtil.js
@@ -74,13 +74,23 @@ oidcUtil.bootstrapPassportStrategy = context => {
     },
     sessionKey: context.options.sessionKey,
     client: context.client
-  }, (tokenSet, userinfo, done) => {
-    return tokenSet && userinfo
-      ? done(null, {
-        userinfo: userinfo,
-        tokens: tokenSet
-      })
-      : done(null);
+  }, (...args) => {
+    // Skip returning userinfo if none
+    if (args.length === 2) {
+      return args[1](null, {
+        tokens: args[0]
+      });
+    }
+
+    // Userinfo if in the response
+    if (args.length === 3) {
+      return args[2](null, {
+        userinfo: args[1],
+        tokens: args[0]
+      });
+    }
+
+    return done(null);
   });
 
   // bypass passport's serializers


### PR DESCRIPTION
Update oidcUtil to allow a callback without userinfo in line with https://github.com/panva/node-openid-client/blob/master/lib/passport_strategy.js#L173

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, the package panva/node-openid-client decides if userinfo should be laoded, using loadUserinfo. If it shouldn't, it fires a callback without the userinfo variable. As such, the callback handler within oidcUtil sees the callback as the userinfo variable, due to there being 1 less argument, which means done isn't a callback. 

Issue Number: N/A

## What is the new behavior?
Allows callbacks from OpenIdClientStratergy without userinfo, in line with the page utilised panva/node-openid-client.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

