### PR TITLE
chore(middleware): Adds appBaseUrl, removes redirect_uri

### DIFF
--- a/.oidc.config.js
+++ b/.oidc.config.js
@@ -26,7 +26,7 @@ module.exports = (overrides = {}) => {
   const webConstants = {
     CLIENT_ID: process.env.WEB_CLIENT_ID || process.env.CLIENT_ID || '{clientId}',
     CLIENT_SECRET: process.env.CLIENT_SECRET || '{clientSecret}',
-    REDIRECT_URI: `${BASE_URI}/authorization-code/callback`,
+    APP_BASE_URL: BASE_URI,
     ...defaults
   };
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
 - yarn install
 
 before_install:
-- curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.9.4
+- curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
 - export PATH="$HOME/.yarn/bin:$PATH"
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start

--- a/packages/oidc-middleware/README.md
+++ b/packages/oidc-middleware/README.md
@@ -11,6 +11,7 @@
 * [Getting started](#getting-started)
 * [Usage guide](#usage-guide)
 * [API reference](#api-reference)
+* [Upgrading](#upgrading)
 * [Contributing](#contributing)
 
 This package makes it easy to get your users logged in with Okta using OpenId Connect (OIDC).  It enables your Express application to participate in the [authorization code flow][auth-code-docs] flow by redirecting the user to Okta for authentication and handling the callback from Okta.  Once this flow is complete, a local session is created and the user context is saved for the duration of the session.
@@ -19,11 +20,12 @@ This package makes it easy to get your users logged in with Okta using OpenId Co
 
 This library uses semantic versioning and follows Okta's [library version policy](https://developer.okta.com/code/library-versions/).
 
-:heavy_check_mark: The current stable major version series is: 1.x
+:heavy_check_mark: The current stable major version series is: 2.x
 
 | Version | Status                    |
 | ------- | ------------------------- |
-| 1.x     | :heavy_check_mark: Stable |
+| 2.x     | :heavy_check_mark: Stable |
+| 1.x     | :x: Deprecated            |
 | 0.x     | :x: Retired               |
 
 The latest release can always be found on the [releases page][github-releases].
@@ -37,7 +39,9 @@ If you run into problems using the SDK, you can:
 
 ## Getting started
 
-Installing the Okta Node JS OIDC MIddlware in your project is simple.
+See [Upgrading](#upgrading) for information on updating to the latest version of the library.
+
+Installing the Okta Node JS OIDC Middlware in your project is simple.
 
 ```sh
 # npm
@@ -67,7 +71,7 @@ const oidc = new ExpressOIDC({
   issuer: 'https://{yourOktaDomain}/oauth2/default',
   client_id: '{clientId}',
   client_secret: '{clientSecret}',
-  redirect_uri: 'http://localhost:3000/authorization-code/callback',
+  appBaseUrl: '{appBaseUrl}',
   scope: 'openid profile'
 });
 
@@ -106,7 +110,7 @@ oidc.on('error', err => {
   * [oidc.router](#oidcrouter)
   * [oidc.on('ready', callback)](#oidconready-callback)
   * [oidc.on('error', callback)](#oidconerror-callback)
-  * [oidc.ensureAuthenticated({ redirectTo?: '/uri' })](#oidcensureauthenticated-redirectto-uri)
+  * [oidc.ensureAuthenticated({ redirectTo?: '/uri' })](#oidcensureauthenticated-redirectto-uri-)
   * [req.isAuthenticated()](#reqisauthenticated)
   * [req.logout()](#reqlogout)
   * [req.userContext](#requsercontext)
@@ -129,7 +133,7 @@ const oidc = new ExpressOIDC({
   issuer: 'https://{yourOktaDomain}/oauth2/default',
   client_id: '{clientId}',
   client_secret: '{clientSecret}',
-  redirect_uri: '{redirectUri}',
+  appBaseUrl: 'https://{yourdomain}',
   scope: 'openid profile'
 });
 ```
@@ -139,10 +143,11 @@ Required config:
 * **issuer** - The OIDC provider (e.g. `https://{yourOktaDomain}/oauth2/default`)
 * **client_id** - An id provided when you create an OIDC app in your Okta Org
 * **client_secret** - A secret provided when you create an OIDC app in your Okta Org
-* **redirect_uri** - The callback for your app. Locally, this is usually `http://localhost:3000/authorization-code/callback`. When deployed, this should be `https://{yourProductionDomain}/authorization-code/callback`.
+* **appBaseUrl** - The base scheme, host, and port (if not 80/443) of your app, not including any path (e.g. http://localhost:3000, not http://localhost:3000/ )  You may specific `loginRedirectUri` to override this setting if you redirect to other apps.
 
 Optional config:
 
+* **loginRedirectUri** - The URI for your app that Okta will redirect users to after sign in to create the local session.  Locally, this is usually `http://localhost:3000/authorization-code/callback`. When deployed, this should be `https://{yourProductionDomain}/authorization-code/callback`.  This will default to `{baseUrl}{routes.loginCallback.path}` if `appBaseUrl` is provided, or the (deprecated) `redirect_uri` if appBaseUrl is not provided.  Unless your redirect is to a different application, it is recommended to NOT set this parameter and instead set `appBaseUrl` and (if different than the default of `/authorization-code/callback`) `routes.loginCallback.path`.
 * **response_type** - Defaults to `code`
 * **scope** - Defaults to `openid`, which will only return the `sub` claim. To obtain more information about the user, use `openid profile`. For a list of scopes and claims, please see [Scope-dependent claims](https://developer.okta.com/standards/OIDC/index.html#scope-dependent-claims-not-always-returned) for more information.
 * **routes** - Allows customization of the generated routes. See [Customizing Routes](#customizing-routes) for details.
@@ -163,10 +168,12 @@ const oidc = new ExpressOIDC({ /* options */ });
 app.use(oidc.router);
 ```
 
-It's required in order for `ensureAuthenticated` and `isAuthenticated` to work and adds the following routes:
+It's required in order for `ensureAuthenticated`, and `isAuthenticated` to work and adds the following routes:
 
 * `/login` - redirects to the Okta sign-in page by default
 * `/authorization-code/callback` - processes the OIDC response, then attaches userinfo to the session
+
+The paths for these generated routes can be customized using the `routes` config, see [Customizing Routes](#customizing-routes) for details.
 
 #### oidc.on('ready', callback)
 
@@ -180,11 +187,14 @@ oidc.on('ready', () => {
 
 #### oidc.on('error', callback)
 
-This is triggered if an error occurs while ExpressOIDC is trying to start.
+This is triggered if an error occurs
+* while ExpressOIDC is trying to start
+* if an error occurs while calling the Okta `/revoke` service endpoint on the users tokens while logging out
+* if the state value for a logout does not match the current session
 
 ```javascript
 oidc.on('error', err => {
-  // An error occurred while setting up OIDC
+  // An error occurred 
 });
 ```
 
@@ -198,7 +208,7 @@ app.get('/protected', oidc.ensureAuthenticated(), (req, res) => {
 });
 ```
 
-The `redirectTo` option can be used to redirect the user to a specific URI on your site, after a successful authentication callback.
+The `redirectTo` option can be used to redirect the user to a specific URI on your site after a successful authentication callback.
 
 #### req.isAuthenticated()
 
@@ -265,22 +275,22 @@ const oidc = new ExpressOIDC({
     login: {
       path: '/different/login'
     },
-    callback: {
+    loginCallback: {
       path: '/different/callback',
       handler: (req, res, next) => {
         // Perform custom logic before final redirect, then call next()
       },
-      defaultRedirect: '/home'
+      afterCallback '/home'
     }
   }
 });
 ```
 
-* **`callback.defaultRedirect`** - Where the user is redirected to after a successful authentication callback, if no `returnTo` value was specified by `oidc.ensureAuthenticated()`. Defaults to `/`.
-* **`callback.failureRedirect`** - Where the user is redirected to after authentication failure, defaults to a page which just shows error message.
-* **`callback.handler`** - A function that is called after a successful authentication callback, but before the final redirect within your application. Useful for requirements such as conditional post-authentication redirects, or sending data to logging systems.
-* **`callback.path`** - The URI that this library will host the callback handler on. Defaults to `/authorization-code/callback`
-* **`login.path`** - The URI that redirects the user to the authorize endpoint. Defaults to `/login`.
+* **`loginCallback.afterCallback`** - Where the user is redirected to after a successful authentication callback, if no `redirectTo` value was specified by `oidc.ensureAuthenticated()`. Defaults to `/`.
+* **`loginCallback.failureRedirect`** - Where the user is redirected to after authentication failure. Defaults to a page which just shows error message.
+* **`loginCallback.handler`** - A function that is called after a successful authentication callback, but before the final redirect within your application. Useful for requirements such as conditional post-authentication redirects, or sending data to logging systems.
+* **`loginCallback.path`** - The URI that this library will host the login callback handler on. Defaults to `/authorization-code/callback`.  Must match a value from the Login Redirect Uri list from the Okta console for this application.
+* **`login.path`** - The URI that redirects the user to the Okta authorize endpoint. Defaults to `/login`.
 
 #### Using a Custom Login Page
 
@@ -365,6 +375,20 @@ Once you have done that you can read the documentation on the [request][] librar
 [devforum]: https://devforum.okta.com/
 [openid-client]: https://github.com/panva/node-openid-client
 [request]: https://github.com/request/request
+
+### Upgrading 
+
+#### from 1.x to 2.x
+
+The 2.x improves support for default options without removing flexibility 
+
+Any customization previously done to `routes.callback` should now be done to `routes.loginCallback` as the name of that property object has changed.
+
+Any value previously set for `routes.callback.defaultRedirect` should now be done to `routes.loginCallback.afterCallback`.  
+
+##### Okta with additional apps
+
+If you had the `redirect_uri` pointing to a different application than this one, replace `redirect_uri` with `loginRedirectUri`.
 
 ## Contributing
 

--- a/packages/oidc-middleware/README.md
+++ b/packages/oidc-middleware/README.md
@@ -382,13 +382,15 @@ Once you have done that you can read the documentation on the [request][] librar
 
 The 2.x improves support for default options without removing flexibility 
 
+Specify the `appBaseUrl` property in your config - this is the base scheme + domain + port for your application that will be used for generating the URIs validated against the Okta settings for your application.
+
+Remove the `redirect_uri` property in your config.
++  * If you are using the Okta default value (appBaseUrl + /authorization-code/callback) it will be given a route by default, no additional configuration required.
++  * If you are NOT using the Okta default value, but are using a route on the same server indicated by your appBaseUrl, you should define your login callback path in your routes.loginCallback.path config (see [the API reference](#expressoidc-api)).
+
 Any customization previously done to `routes.callback` should now be done to `routes.loginCallback` as the name of that property object has changed.
 
 Any value previously set for `routes.callback.defaultRedirect` should now be done to `routes.loginCallback.afterCallback`.  
-
-##### Okta with additional apps
-
-If you had the `redirect_uri` pointing to a different application than this one, replace `redirect_uri` with `loginRedirectUri`.
 
 ## Contributing
 

--- a/packages/oidc-middleware/package.json
+++ b/packages/oidc-middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okta/oidc-middleware",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "OpenId Connect middleware for authorization code flows",
   "repository": "https://github.com/okta/okta-oidc-js",
   "homepage": "https://github.com/okta/okta-oidc-js/tree/master/packages/oidc-middleware",
@@ -27,7 +27,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@okta/configuration-validation": "^0.1.1",
+    "@okta/configuration-validation": "^0.2.0",
     "body-parser": "^1.18.2",
     "connect-ensure-login": "^0.1.1",
     "csurf": "^1.9.0",

--- a/packages/oidc-middleware/src/oidcUtil.js
+++ b/packages/oidc-middleware/src/oidcUtil.js
@@ -44,7 +44,7 @@ oidcUtil.createClient = context => {
     issuer,
     client_id,
     client_secret,
-    loginRedirectUri: redirect_uri,    
+    loginRedirectUri: redirect_uri,
     maxClockSkew,
     timeout
   } = context.options;

--- a/packages/oidc-middleware/src/oidcUtil.js
+++ b/packages/oidc-middleware/src/oidcUtil.js
@@ -44,7 +44,7 @@ oidcUtil.createClient = context => {
     issuer,
     client_id,
     client_secret,
-    redirect_uri,
+    loginRedirectUri: redirect_uri,    
     maxClockSkew,
     timeout
   } = context.options;
@@ -87,7 +87,7 @@ oidcUtil.bootstrapPassportStrategy = context => {
   passport.serializeUser((user, done) => done(null, user));
   passport.deserializeUser((user, done) => done(null, user));
   passport.use('oidc', oidcStrategy);
-}
+};
 
 oidcUtil.ensureAuthenticated = (context, options) => {
   options = options || context.options.routes.login.path;
@@ -102,4 +102,4 @@ oidcUtil.ensureAuthenticated = (context, options) => {
       res.sendStatus(401);
     }
   };
-}
+};

--- a/packages/oidc-middleware/test/e2e/harness/server.js
+++ b/packages/oidc-middleware/test/e2e/harness/server.js
@@ -73,7 +73,7 @@ module.exports = class DemoServer {
     });
   }
   stop() {
-    console.log('Sever shutting down');
+    console.log('Server shutting down');
     return new Promise((resolve, reject) => {
       this.httpServer.destroy((err) => {
         console.log('Server destroyed')

--- a/packages/oidc-middleware/test/e2e/specs/basic.js
+++ b/packages/oidc-middleware/test/e2e/specs/basic.js
@@ -26,6 +26,7 @@ describe('Basic login redirect', () => {
       issuer: constants.ISSUER,
       client_id: constants.CLIENT_ID,
       client_secret: constants.CLIENT_SECRET,
+      appBaseUrl: constants.APP_BASE_URL,
       testing: {
         disableHttpsCheck: constants.OKTA_TESTING_DISABLEHTTPSCHECK
       }

--- a/packages/oidc-middleware/test/e2e/specs/custom-login-page.js
+++ b/packages/oidc-middleware/test/e2e/specs/custom-login-page.js
@@ -24,10 +24,11 @@ describe('Custom login page', () => {
       issuer: constants.ISSUER,
       client_id: constants.CLIENT_ID,
       client_secret: constants.CLIENT_SECRET,
+      appBaseUrl: constants.APP_BASE_URL,
       testing: {
-          disableHttpsCheck: constants.OKTA_TESTING_DISABLEHTTPSCHECK
-        }
-    }
+        disableHttpsCheck: constants.OKTA_TESTING_DISABLEHTTPSCHECK
+      }
+    };
 
     server = util.createDemoServerWithCustomLoginPage(serverOptions);
     await server.start();

--- a/packages/oidc-middleware/test/e2e/util/util.js
+++ b/packages/oidc-middleware/test/e2e/util/util.js
@@ -21,7 +21,7 @@ const environmentConfig = {
   issuer: constants.ISSUER,
   client_id: constants.CLIENT_ID,
   client_secret: constants.CLIENT_SECRET,
-  redirect_uri: constants.REDIRECT_URI,
+  appBaseUrl: constants.APP_BASE_URL,
   scope: 'profile email openid'
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -566,6 +566,11 @@
     pouchdb-collections "^1.0.1"
     tiny-queue "^0.2.1"
 
+"@okta/configuration-validation@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@okta/configuration-validation/-/configuration-validation-0.1.1.tgz#b19ee16b0fc9f01a7406229b25af6265e91ae942"
+  integrity sha512-nXULaL9l6W5eODVgXxvr0wmde3nE6JLSmGBpZ0axPsaLLx3wo/aY5mC1JwWtIF1kyrfzRHEHIPmdUZ+U5xq/CQ==
+
 "@okta/okta-auth-js@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-2.0.1.tgz#9d6e636fd3acb1b4fa27d5ff7473a54edf235d36"


### PR DESCRIPTION
BREAKING CHANGE:

Configurations now require appBaseUrl.
redirect_uri is deprecated

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The ExpressOIDC() constructor expects to be passed a `redirect_uri` param

The optional `routes` option has a `callback` param that can have a `defaultRedirect` option
Issue Number: N/A


## What is the new behavior?
The ExpressOIDC() constructor expects an `appBaseUrl` param (it will construct default `redirect_uri` from that and the `routes`, be those default or custom)
* `routes.callback` is now `routes.loginCallback`
* `routes.callback.defaultRedirect` is now `routes.loginCallback.afterCallback`

## Does this PR introduce a breaking change?
- [X] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

See "Updating" in the README

## Other information

There will be a follow-up breaking change to add a new default `/logout` route

## Reviewers
@manueltanzi-okta @robertdamphousse-okta  
