### PR TITLE
Fixes chrome driver version to 2.45

### DIFF
--- a/packages/oidc-middleware/package.json
+++ b/packages/oidc-middleware/package.json
@@ -17,7 +17,7 @@
   "main": "index.js",
   "scripts": {
     "test": "yarn test:unit && yarn test:e2e && yarn test:integration",
-    "pretest:e2e": "./node_modules/.bin/webdriver-manager update --gecko false",
+    "pretest:e2e": "./node_modules/.bin/webdriver-manager update --versions.chrome 2.45 --gecko false",
     "test:e2e": "protractor test/e2e/conf.js",
     "test:integration": "../../scripts/tck.sh",
     "test:unit": "jest test/unit"

--- a/packages/okta-angular/test/e2e/harness/package.json
+++ b/packages/okta-angular/test/e2e/harness/package.json
@@ -7,10 +7,10 @@
     "start": "yarn env && ng serve --port=3000",
     "env": "node ./scripts/prebuild.js",
     "build": "ng build",
-    "pretest": "./node_modules/.bin/webdriver-manager update --gecko false",
+    "pretest": "./node_modules/.bin/webdriver-manager update --versions.chrome 2.45 --gecko false",
     "test": "ng test --watch=false",
     "lint": "ng lint",
-    "pree2e": "./node_modules/.bin/webdriver-manager update --gecko false",
+    "pree2e": "./node_modules/.bin/webdriver-manager update --versions.chrome 2.45 --gecko false",
     "e2e": "yarn env && ng e2e --port 3000 --no-webdriver-update"
   },
   "private": true,

--- a/packages/okta-react/test/e2e/harness/package.json
+++ b/packages/okta-react/test/e2e/harness/package.json
@@ -25,7 +25,7 @@
     "build": "CLIENT_ID=${SPA_CLIENT_ID:=$CLIENT_ID} && REACT_APP_ISSUER=$ISSUER REACT_APP_CLIENT_ID=$CLIENT_ID PORT=8080 OKTA_TESTING_DISABLEHTTPSCHECK=$OKTA_TESTING_DISABLEHTTPSCHECK react-scripts build",
     "build:test": "rimraf e2e/dist && babel e2e/ -d e2e/dist",
     "kill:port": "kill -9 $(lsof -t -i:8080 -sTCP:LISTEN) || true",
-    "pretest": "yarn kill:port && ./node_modules/.bin/webdriver-manager update --gecko false && yarn build:test",
+    "pretest": "yarn kill:port && ./node_modules/.bin/webdriver-manager update --versions.chrome 2.45  --gecko false && yarn build:test",
     "wait:server": "BROWSER=none yarn start & ./node_modules/.bin/wait-on http://localhost:8080",
     "test": "yarn build && yarn wait:server && yarn protractor",
     "eject": "react-scripts eject",

--- a/packages/okta-vue/test/e2e/harness/package.json
+++ b/packages/okta-vue/test/e2e/harness/package.json
@@ -8,7 +8,7 @@
     "dev": "webpack-dev-server --inline --progress --config build/webpack.dev.conf.js",
     "start": "yarn env && yarn dev",
     "env": "node ./scripts/prebuild.js",
-    "pree2e": "sh ./scripts/downloadChromeDriver.sh && ./node_modules/.bin/webdriver-manager update --gecko false",
+    "pree2e": "sh ./scripts/downloadChromeDriver.sh && ./node_modules/.bin/webdriver-manager update --versions.chrome 2.45 --gecko false",
     "e2e": "node test/e2e/runner.js",
     "test": "yarn env && yarn e2e",
     "lint": "eslint --ext .js,.vue src test/e2e/specs",


### PR DESCRIPTION
* oidc-js e2e tests depend on chromedriver
* Since we don't fix chromedriver version in tests, it'll always pick the latest chromedriver version
chromedriver requires specific versions of chrome to run. E.g. chromedriver 2.46 requires chrome 71+
* Since we now run these tests on bacon, and bacon has a fixed chrome version, the tests are failing
* The solution is to fix the chromedriver version in our tests, so that we don't have to keep updating the chrome version on bacon each time a new version of chromedriver is released

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

