### PR TITLE
fix(jwt-verifier): Updates deps to get security fix

### DIFF
--- a/packages/jwt-verifier/package.json
+++ b/packages/jwt-verifier/package.json
@@ -25,14 +25,17 @@
     "node": ">=6"
   },
   "jest": {
-    "reporters": [ "default", "jest-junit" ],
+    "reporters": [
+      "default",
+      "jest-junit"
+    ],
     "testEnvironment": "jsdom"
   },
   "license": "Apache-2.0",
   "dependencies": {
     "@okta/configuration-validation": "^0.1.1",
     "jwks-rsa": "^1.2.0",
-    "njwt": "^0.4.0"
+    "njwt": "^1.0.0"
   },
   "devDependencies": {
     "cors": "^2.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8170,12 +8170,13 @@ nightwatch@^1.0.11:
   optionalDependencies:
     mocha "^5.1.1"
 
-njwt@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/njwt/-/njwt-0.4.0.tgz#7324ed9d76a9d54b5e265cb7b6a3c55f146fd3c7"
+njwt@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/njwt/-/njwt-1.0.0.tgz#da5bfa9c251b144a9cdb40a8ad025b3d7b5b52ee"
+  integrity sha512-n+FaPUauVQF/So+YcOACBb/zCxDH5WlCV3dTrX0u7VMGagjDiI39XRJWaPd2PtpT6IpIQUcd7x0twiRZaIQNDQ==
   dependencies:
     ecdsa-sig-formatter "^1.0.5"
-    uuid "^2.0.1"
+    uuid "^3.3.2"
 
 nock@^9.0.14, nock@^9.1.6:
   version "9.6.1"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [X] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`npm audit` flags `njwt` dependency for allowing uninitialized Buffers.

Issue Number: https://github.com/okta/okta-oidc-js/issues/385


## What is the new behavior?

`njwt` has updated to address the issue, this pulls in the updated version.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

While `njwt` has a major version bump in this patch, it is only to drop Node v4, which was already unsupported in this package.

## Other information


## Reviewers

