### PR TITLE
feat: Adds `authenticated` prop to <SecureRoute />

### DIFF
--- a/packages/okta-react/README.md
+++ b/packages/okta-react/README.md
@@ -277,7 +277,7 @@ export default App;
 
 ### `SecureRoute`
 
-`SecureRoute` ensures that a route is only rendered if the user is authenticated. If the user is not authenticated, it calls `onAuthRequired` if it exists, otherwise, it redirects to Okta.
+`SecureRoute` ensures that a route is only rendered if the user is authenticated. An optional `authenticated` prop allows you to prevent remounting & handle the initial render of the route if you are navigating and rendering the same route. If the user is not authenticated, it calls `onAuthRequired` if it exists, otherwise, it redirects to Okta.
 
 ### `ImplicitCallback`
 

--- a/packages/okta-react/src/SecureRoute.js
+++ b/packages/okta-react/src/SecureRoute.js
@@ -46,7 +46,7 @@ class SecureRoute extends Component {
     super(props);
 
     this.state = {
-      authenticated: null
+      authenticated: props.authenticated || null
     };
 
     this.checkAuthentication = this.checkAuthentication.bind(this);

--- a/packages/okta-react/test/jest/secureRoute.test.js
+++ b/packages/okta-react/test/jest/secureRoute.test.js
@@ -72,6 +72,33 @@ describe('<SecureRoute />', () => {
     );
     expect(wrapper.find(SecureRoute).props().sensitive).toBe(true);
   });
+  it('should not immediately render when not provided an "authenticated" prop', () => {
+    const wrapper = mount(
+      <MemoryRouter>
+        <Security {...mockProps}>
+          <SecureRoute
+            path='/'
+            render={() => <div className="doNotRenderThis" />}
+          />
+        </Security>
+      </MemoryRouter>
+    );
+    expect(wrapper.find('.doNotRenderThis').length).toBe(0);
+  });
+  it('should accept a "authenticated" override initial prop and initialize state to its value', () => {
+    const wrapper = mount(
+      <MemoryRouter>
+        <Security {...mockProps}>
+          <SecureRoute
+            path='/'
+            authenticated
+            render={() => <div className="renderThis" />}
+          />
+        </Security>
+      </MemoryRouter>
+    );
+    expect(wrapper.find('.renderThis').length).toBe(1);
+  });
   it('should accept an "exact" prop and pass it to an internal Route', () => {
     const wrapper = mount(
       <MemoryRouter>


### PR DESCRIPTION
Allows an override of the initial authenticated state for
`<SecureRoute />`s, to avoid a `null -> {render function}` cycle
on navigating to the same route.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When navigating to the same `<SecureRoute />`, the component briefly disappears and rerenders due
to the authenticated state being set to null, and `<RenderWrapper />` returning null on first load.

Issue Number: N/A


## What is the new behavior?
This update provides an option to override this behaviour if the authentication state is handled
outside `<SecureRoute />`, and the authenticated status is known and available to provide as an initial state.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

