### PR TITLE
Deprecate initAuth method (not supported with static AOT compile)

### DIFF
--- a/packages/okta-angular/README.md
+++ b/packages/okta-angular/README.md
@@ -11,6 +11,8 @@ This library currently supports:
 
 This library is tested against the latest version of Angular (currently 6), and is currently known to be compatable with Angular 4, 5, and 6.
 
+`okta-angular` works directly with [`@angular/router`](https://angular.io/guide/router). 
+
 ## Getting Started
 
 - If you do not already have a **Developer Edition Account**, you can create one at [https://developer.okta.com/signup/](https://developer.okta.com/signup/).
@@ -39,17 +41,39 @@ yarn add @okta/okta-angular
 
 ## Usage
 
-`okta-angular` works directly with [`@angular/router`](https://angular.io/guide/router) and provides the additional components and services:
+Add [`OktaAuthModule`](#oktaauthmodule) to your module's imports.
+Create a configuration object and provide this as [`OKTA_CONFIG`](#okta_config).
 
-- [`OktaAuthModule`](#oktaauthmodule) - Allows you to supply your OpenID Connect client configuration.
-- [`OktaAuthGuard`](#oktaauthguard) - A navigation guard using [CanActivate](https://angular.io/api/router/CanActivate) to grant access to a page only after successful authentication.
-- [`OktaCallbackComponent`](#oktacallbackcomponent) - Handles the implicit flow callback by parsing tokens from the URL and storing them automatically.
-- [`OktaLoginRedirectComponent`](#oktaloginredirectcomponent) - Redirects users to the Okta Hosted Login Page for authentication.
-- [`OktaAuthService`](#oktaauthservice) - Highest-level service containing the `okta-angular` public methods.
 
-### `OktaAuthModule`
+```typescript
+// myApp.module.ts
 
-The `OktaAuthModule` is the initializer for your OpenID Connect client configuration. It accepts the following properties:
+import {
+  OKTA_CONFIG,
+  OktaAuthModule
+} from '@okta/okta-angular';
+
+const oktaConfig = {
+  issuer: 'https://{yourOktaDomain}.com/oauth2/default',
+  clientId: '{clientId}',
+  redirectUri: 'http://localhost:{port}/implicit/callback'
+}
+
+@NgModule({
+  imports: [
+    ...
+    OktaAuthModule
+  ],
+  providers: [
+    { provide: OKTA_CONFIG, useValue: oktaConfig }
+  ],
+})
+export class MyAppModule { }
+```
+
+### `OKTA_CONFIG`
+
+An Angular InjectionToken used to configure the OktaAuthService. This value must be provided by your own application. It is initialized by a plain object which can have the following properties:
 
 - `issuer` **(required)**: The OpenID Connect `issuer`
 - `clientId` **(required)**: The OpenID Connect `client_id`
@@ -68,31 +92,14 @@ The `OktaAuthModule` is the initializer for your OpenID Connect client configura
 - `autoRenew` *(optional)*:
   By default, the library will attempt to renew expired tokens. When an expired token is requested by the library, a renewal request is executed to update the token. If you wish to  to disable auto renewal of tokens, set autoRenew to false.
 
-```typescript
-// myApp.module.ts
+### `OktaAuthModule`
 
-import {
-  OktaAuthModule
-} from '@okta/okta-angular';
+The top-level Angular module which provides these components and services:
 
-const oktaConfig = {
-  issuer: 'https://{yourOktaDomain}.com/oauth2/default',
-  clientId: '{clientId}',
-  redirectUri: 'http://localhost:{port}/implicit/callback'
-}
-
-const appRoutes: Routes = [
-  ...
-]
-
-@NgModule({
-  imports: [
-    ...
-    OktaAuthModule.initAuth(oktaConfig)
-  ],
-})
-export class MyAppModule { }
-```
+- [`OktaAuthGuard`](#oktaauthguard) - A navigation guard using [CanActivate](https://angular.io/api/router/CanActivate) to grant access to a page only after successful authentication.
+- [`OktaCallbackComponent`](#oktacallbackcomponent) - Handles the implicit flow callback by parsing tokens from the URL and storing them automatically.
+- [`OktaLoginRedirectComponent`](#oktaloginredirectcomponent) - Redirects users to the Okta Hosted Login Page for authentication.
+- [`OktaAuthService`](#oktaauthservice) - Highest-level service containing the `okta-angular` public methods.
 
 ### `OktaAuthGuard`
 

--- a/packages/okta-angular/src/okta/createService.ts
+++ b/packages/okta-angular/src/okta/createService.ts
@@ -1,0 +1,7 @@
+import { OktaConfig } from './models/okta.config';
+import { Router } from '@angular/router';
+import { OktaAuthService } from './services/okta.service';
+
+export function createOktaService(config:OktaConfig, router:Router) {
+  return new OktaAuthService(config, router);
+}

--- a/packages/okta-angular/src/okta/okta.module.ts
+++ b/packages/okta-angular/src/okta/okta.module.ts
@@ -22,11 +22,11 @@ import { Router } from '@angular/router';
 @NgModule({
   declarations: [
     OktaCallbackComponent,
-    OktaLoginRedirectComponent,
+    OktaLoginRedirectComponent
   ],
   exports: [
     OktaCallbackComponent,
-    OktaLoginRedirectComponent,
+    OktaLoginRedirectComponent
   ],
   providers: [
     OktaAuthGuard,
@@ -47,8 +47,8 @@ export class OktaAuthModule {
       ngModule: OktaAuthModule,
       providers: [
         // Will NOT provide config when using AOT compiler. Your app module should provide this value statically in its providers section.
-        { provide: OKTA_CONFIG, useValue: config },
-      ],
+        { provide: OKTA_CONFIG, useValue: config }
+      ]
     };
   }
 }

--- a/packages/okta-angular/src/okta/okta.module.ts
+++ b/packages/okta-angular/src/okta/okta.module.ts
@@ -16,26 +16,39 @@ import { OktaCallbackComponent, OktaLoginRedirectComponent } from './components/
 import { OktaAuthService } from './services/okta.service';
 import { OktaAuthGuard } from './okta.guard';
 import { OktaConfig, OKTA_CONFIG } from './models/okta.config';
+import { createOktaService } from './createService';
+import { Router } from '@angular/router';
 
 @NgModule({
   declarations: [
     OktaCallbackComponent,
-    OktaLoginRedirectComponent
+    OktaLoginRedirectComponent,
   ],
   exports: [
     OktaCallbackComponent,
-    OktaLoginRedirectComponent
+    OktaLoginRedirectComponent,
+  ],
+  providers: [
+    OktaAuthGuard,
+    {
+      provide: OktaAuthService,
+      useFactory: createOktaService,
+      deps: [
+        OKTA_CONFIG,
+        Router
+      ]
+    }
   ]
 })
 export class OktaAuthModule {
+  // Deprecated. Your app should provide OKTA_CONFIG directly
   static initAuth(config: OktaConfig): ModuleWithProviders {
     return {
       ngModule: OktaAuthModule,
       providers: [
-        OktaAuthGuard,
-        OktaAuthService,
-        { provide: OKTA_CONFIG, useValue: config }
-      ]
+        // Will NOT provide config when using AOT compiler. Your app module should provide this value statically in its providers section.
+        { provide: OKTA_CONFIG, useValue: config },
+      ],
     };
   }
 }


### PR DESCRIPTION
Use factory method to clarify dependencies. Add comments to clarify behavior.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Deprecates the initAuth() method, now callers can simply import the OktaAuthModule without calling a static "helper".  For non-AOT cases, callers can still use the initAuth() method as shown in older samples. To work with AOT, however, the caller must provide the OKTA_CONFIG value in a static way so that it will work with AOT compilation. Calling the static method is a dynamic way of specifying the config.  Currently we are using DI at construction time so config can not be dynamic.

Issue Number: https://github.com/okta/okta-oidc-js/issues/176


## What is the new behavior?
initAuth() is no longer required to be called. All dependencies are defined by ngModule decorator

## Does this PR introduce a breaking change?
- [ ] Yes
- [X ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

