### PR TITLE
fix[okta-react-native]: Fixes client_id error in refreshAccessToken

### DIFF
--- a/packages/okta-react-native/src/oidc.js
+++ b/packages/okta-react-native/src/oidc.js
@@ -113,7 +113,7 @@ export async function refreshAccessToken(client, options) {
 
   // Create token endpoint params
   options = Object.assign({
-    client_id: client.client_id,
+    client_id: client.config.client_id,
     grant_type: 'refresh_token',
     refresh_token: authContext.refreshToken.string
   }, options);


### PR DESCRIPTION
Fixes a bug in refreshAccessToken method where client_id is not properly assigned
a value from the client.config object. Refresh currently works if the access token
is not expired, but otherwise will not refresh properly 
(OidcError: No client credentials found)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x ] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently when an access token is expired and refreshAccessToken is called, the client_id value is null and exception of OidcError: No client credentials is generated

Issue Number: N/A


## What is the new behavior?
By adjusting client.client_id to client.config.client_id the proper object is set to our client_id and refreshAccessToken works properly to generate new access token

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

