### PR TITLE
Require "https://" redirectUri unless running on localhost or testing.disableHttpsCheck

### DIFF
--- a/packages/configuration-validation/README.md
+++ b/packages/configuration-validation/README.md
@@ -50,6 +50,12 @@ Assert that a valid `redirectUri` was provided.
 
 ```javascript
 assertRedirectUri('https://example.com/callback');
+
+// Ignore HTTPS requirement for testing
+assertRedirectUri('http://localhost:8080/', {
+  disableHttpsCheck: true
+});
+
 ```
 
 ### assertAppBaseUrl(appBaseUrl)
@@ -58,6 +64,12 @@ Assert that a valid `appBaseUrl` was provided.
 
 ```javascript
 assertAppBaseUrl('https://example.com');
+
+// Ignore HTTPS requirement for testing
+assertAppBaseUrl('http://localhost:8080/', {
+  disableHttpsCheck: true
+});
+
 ```
 
 ## Contributing

--- a/packages/oidc-middleware/src/ExpressOIDC.js
+++ b/packages/oidc-middleware/src/ExpressOIDC.js
@@ -76,7 +76,7 @@ module.exports = class ExpressOIDC extends EventEmitter {
     assertClientSecret(client_secret);
 
     // Validate the appBaseUrl param
-    assertAppBaseUrl(appBaseUrl);
+    assertAppBaseUrl(appBaseUrl, options.testing);
 
     // Add defaults to the options
     options = merge({
@@ -107,7 +107,7 @@ module.exports = class ExpressOIDC extends EventEmitter {
     options.logoutRedirectUri = logoutRedirectUri || `${appBaseUrl}${options.routes.logoutCallback.path}`;
 
     // Validate the redirect_uri param
-    assertRedirectUri(options.loginRedirectUri);
+    assertRedirectUri(options.loginRedirectUri, options.testing);
 
     const context = {
       options,

--- a/packages/okta-angular/src/okta/services/okta.service.ts
+++ b/packages/okta-angular/src/okta/services/okta.service.ts
@@ -55,7 +55,7 @@ export class OktaAuthService {
       // Assert Configuration
       assertIssuer(this.config.issuer, this.config.testing);
       assertClientId(this.config.clientId);
-      assertRedirectUri(this.config.redirectUri);
+      assertRedirectUri(this.config.redirectUri, this.config.testing);
 
       this.oktaAuth = new OktaAuth(this.config);
       this.oktaAuth.userAgent = `${packageInfo.name}/${packageInfo.version} ${this.oktaAuth.userAgent}`;

--- a/packages/okta-react-native/index.js
+++ b/packages/okta-react-native/index.js
@@ -25,8 +25,8 @@ export const createConfig = async({
 
   assertIssuer(discoveryUri);
   assertClientId(clientId);
-  assertRedirectUri(redirectUri);
-  assertRedirectUri(endSessionRedirectUri);
+  assertRedirectUri(redirectUri, { disableHttpsCheck: true});
+  assertRedirectUri(endSessionRedirectUri, { disableHttpsCheck: true});
 
   if (Platform.OS === 'ios') {
     scopes = scopes.join(' ');

--- a/packages/okta-react/src/Auth.js
+++ b/packages/okta-react/src/Auth.js
@@ -23,16 +23,11 @@ const containsAuthTokens = /id_token|access_token|code/;
 
 export default class Auth {
   constructor(config) {
-    const testing = {
-      // If the config is undefined, cast it to false
-      disableHttpsCheck: !!config.disableHttpsCheck
-    };
-
     // normalize authJS config. In this SDK, we allow underscore on certain properties, but AuthJS consistently uses camel case.
     const authConfig = buildConfigObject(config);
-    assertIssuer(authConfig.issuer, testing);
+    assertIssuer(authConfig.issuer, authConfig.testing);
     assertClientId(authConfig.clientId);
-    assertRedirectUri(authConfig.redirectUri);
+    assertRedirectUri(authConfig.redirectUri, authConfig.testing);
     this._oktaAuth = new OktaAuth(authConfig);
     this._oktaAuth.userAgent = `${packageInfo.name}/${packageInfo.version} ${this._oktaAuth.userAgent}`;
     this._config = authConfig; // use normalized config

--- a/packages/okta-react/test/jest/auth.test.js
+++ b/packages/okta-react/test/jest/auth.test.js
@@ -175,7 +175,7 @@ describe('Auth configuration', () => {
     const options = {
       clientId: 'foo',
       issuer: 'https://foo/oauth2/default',
-      redirectUri: 'foo',
+      redirectUri: 'https://foo',
       pkce: true,
     }
 
@@ -196,7 +196,7 @@ describe('Auth component', () => {
     const auth = new Auth({
       issuer: 'https://foo/oauth2/default',
       client_id: 'foo',
-      redirect_uri: 'foo'
+      redirect_uri: 'https://foo'
     });
     const expectedUserAgent = `${pkg.name}/${pkg.version} okta-auth-js`;
     expect(auth._oktaAuth.userAgent).toMatch(expectedUserAgent);
@@ -205,7 +205,7 @@ describe('Auth component', () => {
     const auth = new Auth({
       issuer: 'https://foo/oauth2/default',
       client_id: 'foo',
-      redirect_uri: 'foo'
+      redirect_uri: 'https://foo'
     });
     const accessToken = await auth.getAccessToken();
     expect(accessToken).toBe(mockAccessToken);
@@ -215,7 +215,7 @@ describe('Auth component', () => {
     const auth = new Auth({
       issuer: 'https://foo/oauth2/default',
       client_id: 'foo',
-      redirect_uri: 'foo'
+      redirect_uri: 'https://foo'
     });
     auth.redirect();
     expect(mockAuthJsInstance.token.getWithRedirect).toHaveBeenCalledWith({
@@ -227,7 +227,7 @@ describe('Auth component', () => {
     const auth = new Auth({
       issuer: 'https://foo/oauth2/default',
       client_id: 'foo',
-      redirect_uri: 'foo',
+      redirect_uri: 'https://foo',
       scope: ['openid', 'foo']
     });
     auth.redirect();
@@ -240,7 +240,7 @@ describe('Auth component', () => {
     const auth = new Auth({
       issuer: 'https://foo/oauth2/default',
       client_id: 'foo',
-      redirect_uri: 'foo',
+      redirect_uri: 'https://foo',
       response_type: ['id_token']
     });
     auth.redirect();
@@ -253,7 +253,7 @@ describe('Auth component', () => {
     const auth = new Auth({
       issuer: 'https://foo/oauth2/default',
       client_id: 'foo',
-      redirect_uri: 'foo'
+      redirect_uri: 'https://foo'
     });
     const overrides = {
       scopes: ['openid', 'foo'],
@@ -267,7 +267,7 @@ describe('Auth component', () => {
     const auth = new Auth({
       issuer: 'https://foo/oauth2/default',
       client_id: 'foo',
-      redirect_uri: 'foo'
+      redirect_uri: 'https://foo'
     });
     const overrides = {
       scope: 'openid foo',
@@ -284,7 +284,7 @@ describe('Auth component', () => {
     const auth = new Auth({
       issuer: 'https://foo/oauth2/default',
       client_id: 'foo',
-      redirect_uri: 'foo'
+      redirect_uri: 'https://foo'
     });
     const overrides = {
       scope: ['openid', 'foo'],
@@ -301,7 +301,7 @@ describe('Auth component', () => {
     const auth = new Auth({
       issuer: 'https://foo/oauth2/default',
       client_id: 'foo',
-      redirect_uri: 'foo'
+      redirect_uri: 'https://foo'
     });
     auth.redirect({foo: 'bar'});
     expect(mockAuthJsInstance.token.getWithRedirect).toHaveBeenCalledWith({
@@ -314,7 +314,7 @@ describe('Auth component', () => {
     const auth = new Auth({
       issuer: 'https://foo/oauth2/default',
       client_id: 'foo',
-      redirect_uri: 'foo'
+      redirect_uri: 'https://foo'
     });
     auth.login({foo: 'bar'});
     expect(mockAuthJsInstance.token.getWithRedirect).toHaveBeenCalledWith({
@@ -327,7 +327,7 @@ describe('Auth component', () => {
     const auth = new Auth({
       issuer: 'https://foo/oauth2/default',
       client_id: 'foo',
-      redirect_uri: 'foo'
+      redirect_uri: 'https://foo'
     });
     const authenticated = await auth.isAuthenticated();
     expect(mockAuthJsInstance.tokenManager.get).toHaveBeenCalledWith('accessToken');
@@ -340,7 +340,7 @@ describe('Auth component', () => {
     const auth = new Auth({
       issuer: 'https://foo/oauth2/default',
       client_id: 'foo',
-      redirect_uri: 'foo'
+      redirect_uri: 'https://foo'
     });
     const authenticated = await auth.isAuthenticated();
     expect(authenticated).toBeFalsy();

--- a/packages/okta-vue/src/Auth.js
+++ b/packages/okta-vue/src/Auth.js
@@ -96,9 +96,9 @@ const initConfig = options => {
   let auth = buildConfigObject(options)
 
   // Assert configuration
-  assertIssuer(auth.issuer, auth.testing)
+  assertIssuer(auth.issuer, options.testing)
   assertClientId(auth.clientId)
-  assertRedirectUri(auth.redirectUri)
+  assertRedirectUri(auth.redirectUri, options.testing)
 
   // Ensure "openid" exists in the scopes
   auth.scopes = auth.scopes || []

--- a/packages/okta-vue/test/jest/Auth.config.spec.js
+++ b/packages/okta-vue/test/jest/Auth.config.spec.js
@@ -8,7 +8,7 @@ describe('Auth configuration', () => {
     const validConfig = {
       issuer: 'https://foo',
       clientId: 'foo',
-      redirectUri: 'foo'
+      redirectUri: 'https://foo/redirect'
     }
     function createInstance () {
       const localVue = createLocalVue()
@@ -136,5 +136,32 @@ describe('Auth configuration', () => {
       })
     }
     expect(createInstance).toThrow()
+  })
+
+  it('should throw if a redirect_uri is not https', () => {
+    function createInstance () {
+      const localVue = createLocalVue()
+      localVue.use(Auth, {
+        issuer: 'https://foo/oauth2/default',
+        client_id: 'foo',
+        redirect_uri: 'http://foo'
+      })
+    }
+    expect(createInstance).toThrow()
+  })
+
+  it('should not throw for http redirect_uri is testing.disableHttpsCheck = true', () => {
+    function createInstance () {
+      const localVue = createLocalVue()
+      localVue.use(Auth, {
+        issuer: 'https://foo/oauth2/default',
+        client_id: 'foo',
+        redirect_uri: 'http://foo',
+        testing: {
+          disableHttpsCheck: true
+        }
+      })
+    }
+    expect(createInstance).not.toThrow()
   })
 })

--- a/packages/okta-vue/test/jest/Auth.interface.spec.js
+++ b/packages/okta-vue/test/jest/Auth.interface.spec.js
@@ -8,7 +8,7 @@ jest.mock('@okta/okta-auth-js')
 const baseConfig = {
   issuer: 'https://foo',
   clientId: 'foo',
-  redirectUri: 'foo'
+  redirectUri: 'https://foo/callback'
 }
 
 describe('Auth constructor', () => {
@@ -46,14 +46,14 @@ describe('Auth constructor', () => {
     const legacyConfig = {
       issuer: 'https://foo',
       client_id: 'foo',
-      redirect_uri: 'foo',
+      redirect_uri: 'https://foo/redirect',
       scope: 'foo bar',
       response_type: 'token foo'
     }
     localVue.use(Auth, legacyConfig)
     expect(AuthJS).toHaveBeenCalledWith(Object.assign({}, legacyConfig, {
       clientId: 'foo',
-      redirectUri: 'foo',
+      redirectUri: 'https://foo/redirect',
       scopes: ['openid', 'foo', 'bar'],
       responseType: ['token', 'foo']
     }))


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ Y ] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [ Y ] Tests for the changes have been added (for bug fixes / features)
- [ Y ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ X ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ X ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [  X ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
Insecure `http://` urls are allowed for `redirectUri`. 

## What is the new behavior?
Secure `https://` urls will be required for `redirectUri` unless:
- `testing.disableHttpsCheck` - this will also disable secure cookie setting
- Running on `http://localhost` - specific exemption for local development

## Does this PR introduce a breaking change?
- [ X ] Yes
- [  ] No

With this change, an exception will be thrown if using http:// for redirectUri or appBaseUrl. To allow insecure cookies (and http:// urls), `testing.disableHttpsCheck` can be set to true.  

`http://localhost` is explicitly allowed to support local development and our sample apps. However, with a "secure" cookie setting, cookies will not be stored.

This would affect applications which expect to run in production on the insecure http:// protocol. With these changes, they must explicitly set `disableHttpsCheck`. A warning will still be shown in the developer console.

## Other information

## Reviewers
@swiftone 
