### PR TITLE
Adds support for legacy tests on bacon

### DIFF
--- a/packages/oidc-middleware/package.json
+++ b/packages/oidc-middleware/package.json
@@ -19,6 +19,8 @@
     "test": "yarn test:unit && yarn test:e2e && yarn test:integration",
     "pretest:e2e": "./node_modules/.bin/webdriver-manager update --versions.chrome 2.46 --gecko false",
     "test:e2e": "protractor test/e2e/protractor.conf.js",
+    "pretest:e2e:legacy": "./node_modules/.bin/webdriver-manager update --versions.chrome 2.45 --gecko false",
+    "test:e2e:legacy": "protractor test/e2e/protractor.conf.js",
     "test:integration": "../../scripts/tck.sh",
     "test:unit": "jest test/unit"
   },

--- a/packages/okta-angular/package.json
+++ b/packages/okta-angular/package.json
@@ -20,6 +20,8 @@
     "test": "yarn lint && yarn test:e2e && yarn test:unit",
     "pretest:e2e": "yarn build:dependencies",
     "test:e2e": "yarn --cwd test/e2e/harness/ e2e",
+    "pretest:e2e:legacy": "yarn build:dependencies",
+    "test:e2e:legacy": "yarn --cwd test/e2e/harness/ e2e:legacy",
     "test:unit": "yarn --cwd test/e2e/harness/ test"
   },
   "repository": "https://github.com/okta/okta-oidc-js",

--- a/packages/okta-angular/test/e2e/harness/package.json
+++ b/packages/okta-angular/test/e2e/harness/package.json
@@ -11,7 +11,9 @@
     "test": "ng test --watch=false",
     "lint": "ng lint",
     "pree2e": "./node_modules/.bin/webdriver-manager update --versions.chrome 2.46 --gecko false",
-    "e2e": "yarn env && ng e2e --port 3000 --no-webdriver-update"
+    "e2e": "yarn env && ng e2e --port 3000 --no-webdriver-update",
+    "pree2e:legacy": "./node_modules/.bin/webdriver-manager update --versions.chrome 2.45 --gecko false",
+    "e2e:legacy": "yarn env && ng e2e --port 3000 --no-webdriver-update"
   },
   "private": true,
   "dependencies": {

--- a/packages/okta-react/package.json
+++ b/packages/okta-react/package.json
@@ -16,6 +16,8 @@
     "test": "yarn lint && yarn test:unit && yarn test:e2e",
     "pretest:e2e": "yarn build && yarn build:harness",
     "test:e2e": "yarn --cwd test/e2e/harness test",
+    "pretest:e2e:legacy": "yarn build && yarn build:harness",
+    "test:e2e:legacy": "yarn --cwd test/e2e/harness test:legacy",
     "test:unit": "jest test/jest/"
   },
   "repository": {

--- a/packages/okta-react/test/e2e/harness/package.json
+++ b/packages/okta-react/test/e2e/harness/package.json
@@ -26,9 +26,11 @@
     "build": "CLIENT_ID=${SPA_CLIENT_ID:=$CLIENT_ID} && REACT_APP_ISSUER=$ISSUER REACT_APP_CLIENT_ID=$CLIENT_ID PORT=8080 OKTA_TESTING_DISABLEHTTPSCHECK=$OKTA_TESTING_DISABLEHTTPSCHECK react-scripts build",
     "build:test": "rimraf e2e/dist && babel e2e/ -d e2e/dist",
     "kill:port": "kill -9 $(lsof -t -i:8080 -sTCP:LISTEN) || true",
-    "pretest": "yarn kill:port && ./node_modules/.bin/webdriver-manager update --versions.chrome 2.46 --gecko false && yarn build:test",
     "wait:server": "BROWSER=none yarn start & ./node_modules/.bin/wait-on http://localhost:8080",
+    "pretest": "yarn kill:port && ./node_modules/.bin/webdriver-manager update --versions.chrome 2.46 --gecko false && yarn build:test",
     "test": "yarn build && yarn wait:server && yarn protractor",
+    "pretest:legacy": "yarn kill:port && ./node_modules/.bin/webdriver-manager update --versions.chrome 2.45 --gecko false && yarn build:test",
+    "test:legacy": "yarn build && yarn wait:server && yarn protractor",
     "eject": "react-scripts eject",
     "protractor": "babel-node ./node_modules/.bin/protractor protractor.conf.js"
   },

--- a/packages/okta-vue/package.json
+++ b/packages/okta-vue/package.json
@@ -21,6 +21,8 @@
     "test": "yarn lint && yarn test:unit && yarn test:e2e",
     "pretest:e2e": "yarn kill:port && yarn build && yarn build:harness",
     "test:e2e": "yarn --cwd test/e2e/harness/ test",
+    "pretest:e2e:legacy": "yarn kill:port && yarn build && yarn build:harness",
+    "test:e2e:legacy": "yarn --cwd test/e2e/harness/ test:legacy",
     "test:unit": "jest src/"
   },
   "jest": {

--- a/packages/okta-vue/test/e2e/harness/package.json
+++ b/packages/okta-vue/test/e2e/harness/package.json
@@ -10,7 +10,10 @@
     "env": "node ./scripts/prebuild.js",
     "pree2e": "sh ./scripts/downloadChromeDriver.sh && ./node_modules/.bin/webdriver-manager update --versions.chrome 2.46 --gecko false",
     "e2e": "node test/e2e/runner.js",
+    "pree2e:legacy": "sh ./scripts/downloadChromeDriver.sh legacy && ./node_modules/.bin/webdriver-manager update --versions.chrome 2.45 --gecko false",
+    "e2e:legacy": "node test/e2e/runner.js",
     "test": "yarn env && yarn e2e",
+    "test:legacy": "yarn env && yarn e2e:legacy",
     "lint": "eslint --ext .js,.vue src test/e2e/specs",
     "build": "node build/build.js"
   },

--- a/packages/okta-vue/test/e2e/harness/scripts/downloadChromeDriver.sh
+++ b/packages/okta-vue/test/e2e/harness/scripts/downloadChromeDriver.sh
@@ -1,18 +1,25 @@
 # Install ChromeDriver.
 OS="`uname`"
 
+if [ $# -eq 0 ]
+then
+  CHROME_DRIVER_VERSION=2.46
+else
+  CHROME_DRIVER_VERSION=2.45
+fi
+
 case $OS in
   'Linux')
     OS='Linux'
-    CHROME_DRIVER=http://chromedriver.storage.googleapis.com/2.46/chromedriver_linux64.zip
+    CHROME_DRIVER=http://chromedriver.storage.googleapis.com/${CHROME_DRIVER_VERSION}/chromedriver_linux64.zip
     ;;
   'WindowsNT')
     OS='Windows'
-    CHROME_DRIVER=http://chromedriver.storage.googleapis.com/2.46/chromedriver_win32.zip
+    CHROME_DRIVER=http://chromedriver.storage.googleapis.com/${CHROME_DRIVER_VERSION}/chromedriver_win32.zip
     ;;
   'Darwin')
     OS='Mac'
-    CHROME_DRIVER=http://chromedriver.storage.googleapis.com/2.46/chromedriver_mac64.zip
+    CHROME_DRIVER=http://chromedriver.storage.googleapis.com/${CHROME_DRIVER_VERSION}/chromedriver_mac64.zip
     ;;
   *) ;;
 esac


### PR DESCRIPTION
* We recently updated chrome driver to 2.46 as travis chrome version was upgraded
* This is causing our PDV tests to fail on bacon 
* Added scripts to take care of legacy chrome driver for bacon

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

