### PR TITLE
fix[okta-react]: Allows camelcase clientId and redirectUri config keys

### DIFF
--- a/packages/okta-react/README.md
+++ b/packages/okta-react/README.md
@@ -75,8 +75,8 @@ class App extends Component {
     return (
       <Router>
         <Security issuer='https://{yourOktaDomain}.com/oauth2/default'
-                  client_id='{clientId}'
-                  redirect_uri={window.location.origin + '/implicit/callback'} >
+                  clientId='{clientId}'
+                  redirectUri={window.location.origin + '/implicit/callback'} >
           <Route path='/' exact={true} component={Home}/>
           <SecureRoute path='/protected' component={Protected}/>
           <Route path='/implicit/callback' component={ImplicitCallback} />
@@ -191,8 +191,8 @@ Security is the top-most component of okta-react. This is where most of the conf
 #### Configuration options
 
 - **issuer** (required) - The OpenId Connect `issuer`
-- **client_id** (required) - The OpenId Connect `client_id`
-- **redirect_uri** (required) - Where the callback handler is hosted
+- **clientId** (required) - The OpenId Connect `client_id`
+- **redirectUri** (required) - Where the callback handler is hosted
 - **scope** *(optional)*: Reserved or custom claims to be returned in the tokens
 - **response_type** *(optional)*: Desired token grant types
 - **onAuthRequired** (optional)
@@ -224,8 +224,8 @@ class App extends Component {
     return (
       <Router>
         <Security issuer='https://{yourOktaDomain}.com/oauth2/default'
-                  client_id='{clientId}'
-                  redirect_uri={window.location.origin + '/implicit/callback'}
+                  clientId='{clientId}'
+                  redirectUri={window.location.origin + '/implicit/callback'}
                   onAuthRequired={customAuthHandler} >
           <Router path='/login' component={CustomLoginComponent}>
           {/* some routes here */}
@@ -253,8 +253,8 @@ const history = createBrowserHistory();
 const auth = new Auth({
   history,
   issuer: 'https://{yourOktaDomain}.com/oauth2/default',
-  client_id: '{clientId}',
-  redirect_uri: window.location.origin + '/implicit/callback',
+  clientId: '{clientId}',
+  redirectUri: window.location.origin + '/implicit/callback',
   onAuthRequired: ({history}) => history.push('/login')
 });
 

--- a/packages/okta-react/src/Auth.js
+++ b/packages/okta-react/src/Auth.js
@@ -29,8 +29,8 @@ export default class Auth {
     };
 
     assertIssuer(config.issuer, testing);
-    assertClientId(config.client_id);
-    assertRedirectUri(config.redirect_uri);
+    config.clientId ? assertClientId(config.clientId) : assertClientId(config.client_id);
+    config.redirectUri ? assertRedirectUri(config.redirectUri) : assertRedirectUri(config.redirect_uri);
     this._oktaAuth = new OktaAuth(buildConfigObject(config));
     this._oktaAuth.userAgent = `${packageInfo.name}/${packageInfo.version} ${this._oktaAuth.userAgent}`;
     this._config = config;

--- a/packages/okta-react/test/jest/auth.test.js
+++ b/packages/okta-react/test/jest/auth.test.js
@@ -121,7 +121,7 @@ describe('Auth configuration', () => {
     }
     expect(createInstance).toThrow()
   });
-  it('should throw if the client_id is not provided', () => {
+  it('should throw if the client id is not provided', () => {
     function createInstance () {
       return new Auth({
         issuer: 'https://foo/oauth2/default'
@@ -138,7 +138,16 @@ describe('Auth configuration', () => {
     }
     expect(createInstance).toThrow()
   });
-  it('should throw if the redirect_uri is not provided', () => {
+  it('should throw if a clientId matching {clientId} is provided', () => {
+    function createInstance () {
+      return new Auth({
+        issuer: 'https://foo/oauth2/default',
+        clientId: '{clientId}',
+      });
+    }
+    expect(createInstance).toThrow()
+  });
+  it('should throw if the redirect uri is not provided', () => {
     function createInstance () {
       return new Auth({
         issuer: 'https://foo/oauth2/default',
@@ -147,13 +156,22 @@ describe('Auth configuration', () => {
     }
     expect(createInstance).toThrow();
   });
-
   it('should throw if a redirect_uri matching {redirectUri} is provided', () => {
     function createInstance () {
       return new Auth({
         issuer: 'https://foo/oauth2/default',
         client_id: 'foo',
         redirect_uri: '{redirectUri}'
+      });
+    }
+    expect(createInstance).toThrow();
+  });
+  it('should throw if a redirectUri matching {redirectUri} is provided', () => {
+    function createInstance () {
+      return new Auth({
+        issuer: 'https://foo/oauth2/default',
+        clientId: 'foo',
+        redirectUri: '{redirectUri}'
       });
     }
     expect(createInstance).toThrow();
@@ -180,6 +198,16 @@ describe('Auth component', () => {
       issuer: 'https://foo/oauth2/default',
       client_id: 'foo',
       redirect_uri: 'foo'
+    });
+    const accessToken = await auth.getAccessToken();
+    expect(accessToken).toBe(mockAccessToken);
+    done();
+  });
+  test('can retrieve an accessToken from the with camelcase config keys', async (done) => {
+    const auth = new Auth({
+      issuer: 'https://foo/oauth2/default',
+      clientId: 'foo',
+      redirectUri: 'foo'
     });
     const accessToken = await auth.getAccessToken();
     expect(accessToken).toBe(mockAccessToken);


### PR DESCRIPTION
Changes configuration validation assertions for auth to allow
camelcase keys for client id and redirect url

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
client_id and redirect_uri auth params are required, breaking the ESLint rule `@typescript-eslint/camelcase`

Issue Number: N/A


## What is the new behavior?
Both sets of params (client_id/redirect_uri and clientId/redirectUri) are allowed, enabling ESLint  compliance with rule `@typescript-eslint/camelcase`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

