### PR TITLE
test(jwt-verifier): Adds debugging output for flaky test

### DIFF
--- a/packages/jwt-verifier/test/spec/verifier.spec.js
+++ b/packages/jwt-verifier/test/spec/verifier.spec.js
@@ -142,9 +142,15 @@ describe('Jwt Verifier', () => {
       return getAccessToken(issuer1AccessTokenParams)
       .then(accessToken =>
         verifier.verifyAccessToken(accessToken)
-        .catch(err => expect(err.message).toBe(
-          `claim 'cid' value '${CLIENT_ID}' does not match expected value 'baz', claim 'foo' value 'undefined' does not match expected value 'bar'`
-        )));
+        .catch(err => {
+          // Extra debugging for an intermittent issue
+          const result = typeof accessToken === 'string' ? 'accessToken is a string' : accessToken;
+          expect(result).toBe('accessToken is a string');
+          expect(err.message).toBe(
+            `claim 'cid' value '${CLIENT_ID}' does not match expected value 'baz', claim 'foo' value 'undefined' does not match expected value 'bar'`
+          );
+        })
+      );
     });
   
     it('should cache the jwks for the configured amount of time', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [X] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?

On rare-but-too-common occasions the test will fail with `jwtString.split is not a function`.

Let's figure out what jwtString is then, because it REALLY should be a string.  

This failure only occurs in CI testing, not locally.

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

