### PR TITLE
fix[okta-react-native]: Fixes client_id call when refreshing token

### DIFF
--- a/packages/okta-react-native/src/oidc.js
+++ b/packages/okta-react-native/src/oidc.js
@@ -113,7 +113,7 @@ export async function refreshAccessToken(client, options) {
 
   // Create token endpoint params
   options = Object.assign({
-    client_id: client.client_id,
+    client_id: client.config.client_id,
     grant_type: 'refresh_token',
     refresh_token: authContext.refreshToken.string
   }, options);


### PR DESCRIPTION
Original "client.client_id" returns undefined causing token refresh to fail. Calling "client.config.client_id" returns the expected value. 


## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [*] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
When trying to refresh a token, client_id is called incorrectly, resulting in it being undefined. This causes the token request to fail because it does not have the correct client_id value, and the access token is never refreshed.

Issue Number: N/A


## What is the new behavior?
Client_id is now retrieved correctly, and token refreshes as expected.

## Does this PR introduce a breaking change?
- [ ] Yes
- [*] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

