### PR TITLE
fix [okta-react-native] Pod install failure

### DIFF
--- a/packages/okta-react-native/OktaSdkBridgeReactNative.podspec
+++ b/packages/okta-react-native/OktaSdkBridgeReactNative.podspec
@@ -3,7 +3,7 @@ require "json"
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
 Pod::Spec.new do |s|
-  s.name         = package['name']
+  s.name         = package['podname']
   s.version      = package['version']
   s.summary      = package['description']
   s.license      = package['license']

--- a/packages/okta-react-native/package.json
+++ b/packages/okta-react-native/package.json
@@ -4,6 +4,8 @@
   "version": "1.0.1",
   "description": "Okta OIDC for React Native",
   "main": "index.js",
+  "podname": "OktaSdkBridgeReactNative",
+  "homepage": "https://github.com/okta/okta-oidc-js/tree/master/packages/okta-react-native",
   "scripts": {
     "test": "node_modules/.bin/jest",
     "test:debug": "node --inspect-brk node_modules/jest/bin/jest.js --runInBand"


### PR DESCRIPTION
* Adding new `podname` attribute to package.json. Current package.json name is not a valid name for a pod.
* Adding missing `homepage` attribute to package.json

Resolves #511

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?

Running `pod spec lint --verbose` on the **master** branch fails with the following error:

```
Fetching podspec for `OktaSdkBridgeReactNative` from `../node_modules/@okta/okta-react-native`
[!] The `OktaSdkBridgeReactNative` pod failed to validate due to 1 error:
    - WARN  | source: Git sources should specify a tag.
    - ERROR | [iOS] name: The name of a spec should not contain a slash.
```

Issue Number: 511


## What is the new behavior?

`pod spec lint --verbose` passes

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information


## Reviewers

