### PR TITLE
feat: Introducing custom pathname for ImplicitCallback redirect.

### DIFF
--- a/packages/okta-react/README.md
+++ b/packages/okta-react/README.md
@@ -257,7 +257,7 @@ class App extends Component {
         <Security auth={auth} >
           <Route path='/' exact={true} component={Home}/>
           <SecureRoute path='/protected' component={Protected}/>
-          <Route path='/implicit/callback' component={ImplicitCallback} />
+          <Route path='/implicit/callback' component={() => <ImplicitCallback pathname='/custom/path' />} />
         </Security>
       </Router>
     );
@@ -273,7 +273,7 @@ export default App;
 
 ### `ImplicitCallback`
 
-`ImplicitCallback` handles the callback after the redirect. By default, it parses the tokens from the uri, stores them, then redirects to `/`. If a `SecureRoute` caused the redirect, then the callback redirects to the secured route.
+`ImplicitCallback` handles the callback after the redirect. By default, it parses the tokens from the uri, stores them, then redirects to `/` or the specified default pathname. If a `SecureRoute` caused the redirect, then the callback redirects to the secured route.
 
 ### `withAuth`
 

--- a/packages/okta-react/src/ImplicitCallback.js
+++ b/packages/okta-react/src/ImplicitCallback.js
@@ -15,6 +15,10 @@ import { Redirect } from 'react-router';
 import withAuth from './withAuth';
 
 export default withAuth(class ImplicitCallback extends Component {
+  static defaultProps = {
+    pathname: "/"
+  };
+
   constructor(props) {
     super(props);
 
@@ -36,7 +40,7 @@ export default withAuth(class ImplicitCallback extends Component {
     }
 
     const referrerKey = 'secureRouterReferrerPath';
-    const location = JSON.parse(localStorage.getItem(referrerKey) || '{ "pathname": "/" }');
+    const location = JSON.parse(localStorage.getItem(referrerKey) || JSON.stringify({ pathname: this.props.pathname }));
     localStorage.removeItem(referrerKey);
 
     return this.state.authenticated ?

--- a/packages/okta-react/test/jest/implicitCallback.test.js
+++ b/packages/okta-react/test/jest/implicitCallback.test.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import ImplicitCallback from '../../src/ImplicitCallback';
+
+describe('<ImplicitCallback />', () => {
+  const mockProps = {
+    auth: {}
+  };
+
+  it('should create ImplicitCallback component with default pathname', () => {
+    const wrapper = shallow(
+      <ImplicitCallback auth={mockProps} />
+    );
+    expect(wrapper.dive().props().pathname).toBe('/');
+  });
+
+  it('should create ImplicitCallback component with specified pathname', () => {
+    const wrapper = shallow(
+        <ImplicitCallback auth={mockProps} pathname='/custom/redirect' />
+    );
+    expect(wrapper.dive().props().pathname).toBe('/custom/redirect');
+  });
+
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
The ImplicitCallback component redirects by default to '/', when the referrerPath is not set in local storage.

## What is the new behavior?
The new behavior allows the ImplicitCallback component to define the default pathname for redirect.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No