### PR TITLE
normalize auth config: scopes, requestType

### DIFF
--- a/packages/configuration-validation/src/lib.js
+++ b/packages/configuration-validation/src/lib.js
@@ -38,10 +38,10 @@ configUtil.buildConfigObject = (config) => {
   // Legacy support: allow a property named 'scope' to be either an array or a string.
   let scopes = config.scopes;
   if (!scopes && config.scope) {
-    if (config.scope instanceof Array) {
+    if (Array.isArray(config.scope)) {
       scopes = config.scope;
     } else {
-      scopes = config.scope.split(' ');
+      scopes = config.scope.split(/\s+/);
     }
   }
 
@@ -60,7 +60,7 @@ configUtil.buildConfigObject = (config) => {
   // Legacy support: allow 'responseType' to be a string or an array
   let responseType = config.responseType || config.response_type;
   if (typeof responseType === 'string' && responseType.indexOf(' ') >= 0) {
-    responseType = responseType.split(' ');
+    responseType = responseType.split(/\s+/);
   }
 
   const normalizedConfig = merge({}, config, {

--- a/packages/configuration-validation/src/lib.js
+++ b/packages/configuration-validation/src/lib.js
@@ -32,14 +32,46 @@ configUtil.buildConfigObject = (config) => {
   // See all supported options: https://github.com/okta/okta-auth-js#configuration-reference
   // Support for parameters with an underscore will be deprecated in a future release
   // camelCase was added 2/11/2019: https://github.com/okta/okta-oidc-js/commit/9b04ada6a01c9d9aca391abf0de3e5ecc9811e64
-  return merge({
+  
+  config = config || {}; // accept empty
+
+  // Legacy support: allow a property named 'scope' to be either an array or a string.
+  let scopes = config.scopes;
+  if (!scopes && config.scope) {
+    if (config.scope instanceof Array) {
+      scopes = config.scope;
+    } else {
+      scopes = config.scope.split(' ');
+    }
+  }
+
+  // Legacy support: allow TokenManager config 'autoRenew' and 'storage' to be defined at top-level
+  let tokenManager = config.tokenManager;
+  const autoRenew = config.autoRenew || config.auto_renew;
+  const storage = config.storage;
+  if (storage || autoRenew) {
+    // Properties already defined within the "tokenManager" section will not be overwritten
+    tokenManager = merge({
+      autoRenew: autoRenew,
+      storage: storage,
+    }, tokenManager || {});
+  }
+
+  // Legacy support: allow 'responseType' to be a string or an array
+  let responseType = config.responseType || config.response_type;
+  if (typeof responseType === 'string' && responseType.indexOf(' ') >= 0) {
+    responseType = responseType.split(' ');
+  }
+
+  const normalizedConfig = merge({}, config, {
     clientId: config.clientId || config.client_id,
     redirectUri: config.redirectUri || config.redirect_uri,
-    tokenManager: {
-      autoRenew: config.autoRenew || config.auto_renew,
-      storage: config.storage
-    }
-  }, config);
+    responseType: responseType,
+    scopes: scopes,
+    tokenManager: tokenManager,
+  });
+
+  return normalizedConfig;
 }
 
 configUtil.assertIssuer = (issuer, testing = {}) => {

--- a/packages/configuration-validation/test/lib.test.js
+++ b/packages/configuration-validation/test/lib.test.js
@@ -218,6 +218,18 @@ describe('Configuration Validation', () => {
       });
     });
 
+    it('Converts "scope" (string) to "scopes" (array) (multiple spaces)', () => {
+      const scope = 'a  b  c';
+      const passedConfig = {
+        scope
+      };
+
+      expect(buildConfigObject(passedConfig)).toEqual({
+        scopes: ['a', 'b', 'c'],
+        scope,
+      });
+    });
+
 
     it('Accepts "scope" (as an array)', () => {
       const scope = ['a', 'b', 'c'];
@@ -253,6 +265,19 @@ describe('Configuration Validation', () => {
         responseType: ['a', 'b']
       });
     });
+
+
+    it('Accepts multiple "responseType" (as a string) and converts to array (multi space)', () => {
+      const responseType = 'a   b   x';
+      const passedConfig = {
+        responseType
+      };
+
+      expect(buildConfigObject(passedConfig)).toEqual({
+        responseType: ['a', 'b', 'x']
+      });
+    });
+
 
     it('Accepts multiple "responseType" (as an array)', () => {
       const responseType = ['a', 'b'];

--- a/packages/configuration-validation/test/lib.test.js
+++ b/packages/configuration-validation/test/lib.test.js
@@ -16,23 +16,68 @@ describe('Configuration Validation', () => {
     'find it: https://bit.ly/finding-okta-app-credentials';
 
   describe('buildConfigObject', () => {
-    it('returns correct config object when parameters are passed in camelCase', () => {
+
+    it('can be called with no arguments', () => {
+      expect(buildConfigObject()).toEqual({});
+    });
+
+    it('pass-through: empty config', () => {
+      const passedConfig = {};
+      expect(buildConfigObject(passedConfig)).toEqual(passedConfig);
+    });
+
+    it('pass-through: leaves config object unchanged when all parameters are passed in preferred format', () => {
       const passedConfig = {
         clientId: '{clientId}',
         issuer: '{issuer}',
         redirectUri: '{redirectUri}',
-        storage: '{storage}',
+        responseType: '{responseType}',
+        scopes: ['a', 'b', 'c'],
+        tokenManager: {
+          storage: '{storage}',
+          autoRenew: '{autoRenew}',
+          secure: true,
+        }
+      };
+
+      expect(buildConfigObject(passedConfig)).toEqual(passedConfig);
+    });
+
+    it('pass-through: Allows passing extra config properties at top-level', () => {
+      function f() {}
+      const passedConfig = {
+        onAuthComplete: f
+      }
+
+      expect(buildConfigObject(passedConfig)).toEqual(passedConfig);
+    });
+
+    it('pass-through: tokenManager section', () => {
+      const passedConfig = {
+        tokenManager: {
+          blar: 'foo',
+          storage: 'a',
+          autoRenew: false,
+        }
+      };
+
+      expect(buildConfigObject(passedConfig)).toEqual(passedConfig);
+    });
+
+    it('returns correct config object when parameters are passed in camelCase', () => {
+      const passedConfig = {
+        clientId: '{clientId}',
+        redirectUri: '{redirectUri}',
+        responseType: '{responseType}',
         autoRenew: '{autoRenew}'
       }
 
       expect(buildConfigObject(passedConfig)).toEqual({
         clientId: '{clientId}',
-        issuer: '{issuer}',
         redirectUri: '{redirectUri}',
-        storage: '{storage}',
+        responseType: '{responseType}',
         autoRenew: '{autoRenew}',
         tokenManager: {
-          storage: '{storage}',
           autoRenew: '{autoRenew}'
         }
       });
@@ -41,22 +86,20 @@ describe('Configuration Validation', () => {
     it('returns correct config object when parameters are passed in underscore_case', () => {
       const passedConfig = {
         client_id: '{client_id}',
-        issuer: '{issuer}',
         redirect_uri: '{redirect_uri}',
-        storage: '{storage}',
+        response_type: '{response_type}',
         auto_renew: '{auto_renew}'
       }
 
       expect(buildConfigObject(passedConfig)).toEqual({
         clientId: '{client_id}',
         client_id: '{client_id}',
-        issuer: '{issuer}',
         redirectUri: '{redirect_uri}',
         redirect_uri: '{redirect_uri}',
-        storage: '{storage}',
+        responseType: '{response_type}',
+        response_type: '{response_type}',
         auto_renew: '{auto_renew}',
         tokenManager: {
-          storage: '{storage}',
           autoRenew: '{auto_renew}',
         }
       });
@@ -66,10 +109,8 @@ describe('Configuration Validation', () => {
       const passedConfig = {
         clientId: '{clientId}',
         client_id: '{client_id}',
-        issuer: '{issuer}',
         redirectUri: '{redirectUri}',
         redirect_uri: '{redirect_uri}',
-        storage: '{storage}',
         autoRenew: '{autoRenew}',
         auto_renew: '{auto_renew}'
       }
@@ -77,20 +118,75 @@ describe('Configuration Validation', () => {
       expect(buildConfigObject(passedConfig)).toEqual({
         clientId: '{clientId}',
         client_id: '{client_id}',
-        issuer: '{issuer}',
         redirectUri: '{redirectUri}',
         redirect_uri: '{redirect_uri}',
-        storage: '{storage}',
         autoRenew: '{autoRenew}',
         auto_renew: '{auto_renew}',
         tokenManager: {
-          storage: '{storage}',
           autoRenew: '{autoRenew}',
         }
       });
     });
 
-    it('Allows passing extra config to tokenManager', () => {
+    it('tokenManager section: accepts top-level "storage" prop', () => {
+      const passedConfig = {
+        storage: 'foo',
+      };
+
+      expect(buildConfigObject(passedConfig)).toEqual({
+        storage: 'foo',
+        tokenManager: {
+          storage: 'foo'
+        }
+      });
+    });
+
+    it('tokenManager section: will not overwrite "storage" prop if set within section', () => {
+      const passedConfig = {
+        storage: 'foo',
+        tokenManager: {
+          storage: 'bar'
+        }
+      };
+
+      expect(buildConfigObject(passedConfig)).toEqual({
+        storage: 'foo',
+        tokenManager: {
+          storage: 'bar'
+        }
+      });
+    });
+
+    it('tokenManager section: accepts top-level "autoRenew" prop', () => {
+      const passedConfig = {
+        autoRenew: true,
+      };
+
+      expect(buildConfigObject(passedConfig)).toEqual({
+        autoRenew: true,
+        tokenManager: {
+          autoRenew: true,
+        }
+      });
+    });
+
+    it('tokenManager section: will not overwrite "autoRenew" prop if set within section', () => {
+      const passedConfig = {
+        autoRenew: true,
+        tokenManager: {
+          autoRenew: false,
+        }
+      };
+
+      expect(buildConfigObject(passedConfig)).toEqual({
+        autoRenew: true,
+        tokenManager: {
+          autoRenew: false,
+        }
+      });
+    });
+
+    it('tokenManager section: Allows passing extra config to tokenManager + top-level props', () => {
       const passedConfig = {
         storage: '{storage}',
         autoRenew: '{autoRenew}',
@@ -102,8 +198,6 @@ describe('Configuration Validation', () => {
       expect(buildConfigObject(passedConfig)).toEqual({
         storage: '{storage}',
         autoRenew: '{autoRenew}',
-        clientId: undefined,
-        redirectUri: undefined,
         tokenManager: {
           storage: '{storage}',
           autoRenew: '{autoRenew}',
@@ -112,40 +206,64 @@ describe('Configuration Validation', () => {
       });
     });
 
-    it('Can override tokenManager config', () => {
+    it('Converts "scope" (string) to "scopes" (array)', () => {
+      const scope = 'a b c';
       const passedConfig = {
-        storage: '{storage}',
-        tokenManager: {
-          storage: '{overridden}'
-        }
-      }
+        scope
+      };
 
       expect(buildConfigObject(passedConfig)).toEqual({
-        storage: '{storage}',
-        clientId: undefined,
-        redirectUri: undefined,
-        tokenManager: {
-          storage: '{overridden}',
-        }
+        scopes: ['a', 'b', 'c'],
+        scope,
       });
     });
 
-    it('Allows passing extra config properties at top-level', () => {
-      function f() {}
+
+    it('Accepts "scope" (as an array)', () => {
+      const scope = ['a', 'b', 'c'];
       const passedConfig = {
-        onAuthComplete: f
-      }
+        scope
+      };
 
       expect(buildConfigObject(passedConfig)).toEqual({
-        onAuthComplete: f,
-        clientId: undefined,
-        redirectUri: undefined,
-        tokenManager: {
-          storage: undefined,
-          autoRenew: undefined,
-        }
+        scopes: scope,
+        scope,
       });
-    })
+    });
+
+
+    it('Accepts single "responseType" (as a string)', () => {
+      const responseType = 'a';
+      const passedConfig = {
+        responseType
+      };
+
+      expect(buildConfigObject(passedConfig)).toEqual({
+        responseType: 'a'
+      });
+    });
+
+    it('Accepts multiple "responseType" (as a string) and converts to array', () => {
+      const responseType = 'a b';
+      const passedConfig = {
+        responseType
+      };
+
+      expect(buildConfigObject(passedConfig)).toEqual({
+        responseType: ['a', 'b']
+      });
+    });
+
+    it('Accepts multiple "responseType" (as an array)', () => {
+      const responseType = ['a', 'b'];
+      const passedConfig = {
+        responseType
+      };
+
+      expect(buildConfigObject(passedConfig)).toEqual({
+        responseType: ['a', 'b']
+      });
+    });
   });
 
   describe('assertIssuer', () => {

--- a/packages/okta-angular/README.md
+++ b/packages/okta-angular/README.md
@@ -78,7 +78,7 @@ An Angular InjectionToken used to configure the OktaAuthService. This value must
 - `issuer` **(required)**: The OpenID Connect `issuer`
 - `clientId` **(required)**: The OpenID Connect `client_id`
 - `redirectUri` **(required)**: Where the callback is hosted
-- `scope` *(optional)*: Reserved for custom claims to be returned in the tokens
+- `scopes` *(optional)*: Reserved for custom claims to be returned in the tokens. Defaults to `['openid']`, which will only return the `sub` claim. To obtain more information about the user, use `openid profile`. For a list of scopes and claims, please see [Scope-dependent claims](https://developer.okta.com/standards/OIDC/index.html#scope-dependent-claims-not-always-returned) for more information.
 - `responseType` *(optional)*: Desired token grant types. Default: `['id_token', 'token']`.
 For PKCE flow, this should be left undefined or set to `['code']`.
 - `pkce` *(optional)*: If `true`, PKCE flow will be used
@@ -279,7 +279,7 @@ An observable that returns true/false when the authenticate state changes.  This
 
 #### `oktaAuth.getUser()`
 
-Returns a promise that will resolve with the result of the OpenID Connect `/userinfo` endpoint if an access token is provided, or returns the claims of the ID token if no access token is available.  The returned claims depend on the requested response type, requested scope, and authorization server policies.  For more information see documentation for the [UserInfo endpoint][], [ID Token Claims][], and [Customizing Your Authorization Server][].
+Returns a promise that will resolve with the result of the OpenID Connect `/userinfo` endpoint if an access token is provided, or returns the claims of the ID token if no access token is available.  The returned claims depend on the requested response type, requested scopes, and authorization server policies.  For more information see documentation for the [UserInfo endpoint][], [ID Token Claims][], and [Customizing Your Authorization Server][].
 
 #### `oktaAuth.getAccessToken() Promise<string>`
 

--- a/packages/okta-angular/README.md
+++ b/packages/okta-angular/README.md
@@ -78,6 +78,7 @@ An Angular InjectionToken used to configure the OktaAuthService. This value must
 - `issuer` **(required)**: The OpenID Connect `issuer`
 - `clientId` **(required)**: The OpenID Connect `client_id`
 - `redirectUri` **(required)**: Where the callback is hosted
+- `scope` *(deprecated in v1.2.2)*: Use `scopes` instead
 - `scopes` *(optional)*: Reserved for custom claims to be returned in the tokens. Defaults to `['openid']`, which will only return the `sub` claim. To obtain more information about the user, use `openid profile`. For a list of scopes and claims, please see [Scope-dependent claims](https://developer.okta.com/standards/OIDC/index.html#scope-dependent-claims-not-always-returned) for more information.
 - `responseType` *(optional)*: Desired token grant types. Default: `['id_token', 'token']`.
 For PKCE flow, this should be left undefined or set to `['code']`.

--- a/packages/okta-angular/src/okta/models/okta.config.ts
+++ b/packages/okta-angular/src/okta/models/okta.config.ts
@@ -23,7 +23,8 @@ export interface OktaConfig {
   redirectUri?: string;
   clientId?: string;
   scope?: string;
-  responseType?: string;
+  scopes?: string[];
+  responseType?: any; // can be string or array
   pkce?: boolean;
   onAuthRequired?: AuthRequiredFunction;
   testing?: TestingObject;

--- a/packages/okta-angular/test/e2e/harness/src/app/app.component.spec.ts
+++ b/packages/okta-angular/test/e2e/harness/src/app/app.component.spec.ts
@@ -93,7 +93,7 @@ describe('Unit Tests', () => {
       issuer: environment.ISSUER,
       redirectUri: environment.REDIRECT_URI,
       clientId: environment.CLIENT_ID,
-      scope: 'email',
+      scopes: ['email'],
       responseType: 'id_token',
       testing: {
         disableHttpsCheck: false
@@ -130,7 +130,7 @@ describe('Unit Tests', () => {
     expect(config.issuer).toBe(environment.ISSUER);
     expect(config.redirectUri).toBe(environment.REDIRECT_URI);
     expect(config.clientId).toBe(environment.CLIENT_ID);
-    expect(config.scope).toBe('email openid');
+    expect(config.scopes.join(' ')).toBe('openid email');
     expect(config.responseType).toBe('id_token');
   }));
 

--- a/packages/okta-react/README.md
+++ b/packages/okta-react/README.md
@@ -184,6 +184,7 @@ These options are used by `Security` to configure the [Auth](https://github.com/
 - **issuer** (required) - The OpenId Connect `issuer`
 - **clientId** (required) - The OpenId Connect `client_id`
 - **redirectUri** (required) - Where the callback handler is hosted
+- **scope** *(deprecated in v1.2.3)*: Use `scopes` instead
 - **scopes** *(optional)* - Reserved for custom claims to be returned in the tokens. Default: `['openid', 'email', 'profile']`. For a list of scopes and claims, please see [Scope-dependent claims](https://developer.okta.com/standards/OIDC/index.html#scope-dependent-claims-not-always-returned) for more information.
 - **responseType** *(optional)* - Desired token types. Default: `['id_token', 'token']`.
 For PKCE flow, this should be left undefined or set to `['code']`.

--- a/packages/okta-react/README.md
+++ b/packages/okta-react/README.md
@@ -184,7 +184,7 @@ These options are used by `Security` to configure the [Auth](https://github.com/
 - **issuer** (required) - The OpenId Connect `issuer`
 - **clientId** (required) - The OpenId Connect `client_id`
 - **redirectUri** (required) - Where the callback handler is hosted
-- **scope** *(optional)* - Reserved or custom claims to be returned in the tokens. Default: `['openid', 'email', 'profile']`
+- **scopes** *(optional)* - Reserved for custom claims to be returned in the tokens. Default: `['openid', 'email', 'profile']`. For a list of scopes and claims, please see [Scope-dependent claims](https://developer.okta.com/standards/OIDC/index.html#scope-dependent-claims-not-always-returned) for more information.
 - **responseType** *(optional)* - Desired token types. Default: `['id_token', 'token']`.
 For PKCE flow, this should be left undefined or set to `['code']`.
 - **pkce** *(optional)* - If `true`, PKCE flow will be used

--- a/packages/okta-react/src/Auth.js
+++ b/packages/okta-react/src/Auth.js
@@ -35,7 +35,7 @@ export default class Auth {
     assertRedirectUri(authConfig.redirectUri);
     this._oktaAuth = new OktaAuth(authConfig);
     this._oktaAuth.userAgent = `${packageInfo.name}/${packageInfo.version} ${this._oktaAuth.userAgent}`;
-    this._config = config;
+    this._config = authConfig; // use normalized config
     this._history = config.history;
 
     this.handleAuthentication = this.handleAuthentication.bind(this);
@@ -127,19 +127,19 @@ export default class Auth {
   }
 
   async redirect(additionalParams = {}) {
-    const responseType = additionalParams.response_type
-      || this._config.response_type
+    // normalize config object
+    let params = buildConfigObject(additionalParams);
+
+    // set defaults
+    params.responseType = params.responseType
+      || this._config.responseType
       || ['id_token', 'token'];
 
-    const scopes = additionalParams.scope
-      || this._config.scope
+    params.scopes = params.scopes
+      || this._config.scopes
       || ['openid', 'email', 'profile'];
 
-    this._oktaAuth.token.getWithRedirect({
-      responseType: responseType,
-      scopes: scopes,
-      ...additionalParams
-    });
+    this._oktaAuth.token.getWithRedirect(params);
 
     // return a promise that doesn't terminate so nothing
     // happens after setting window.location

--- a/packages/okta-react/test/jest/auth.test.js
+++ b/packages/okta-react/test/jest/auth.test.js
@@ -176,10 +176,6 @@ describe('Auth configuration', () => {
       clientId: 'foo',
       issuer: 'https://foo/oauth2/default',
       redirectUri: 'foo',
-      tokenManager: {
-        autoRenew: undefined,
-        storage: undefined,
-      },
       pkce: true,
     }
 
@@ -259,12 +255,48 @@ describe('Auth component', () => {
       client_id: 'foo',
       redirect_uri: 'foo'
     });
-    auth.redirect({scope: ['openid', 'foo']});
-    expect(mockAuthJsInstance.token.getWithRedirect).toHaveBeenCalledWith({
-      responseType: ['id_token', 'token'],
-      scopes: ['openid', 'foo']
-    });
+    const overrides = {
+      scopes: ['openid', 'foo'],
+      responseType: ['fake'],
+    };
+    auth.redirect(overrides);
+    expect(mockAuthJsInstance.token.getWithRedirect).toHaveBeenCalledWith(overrides);
   });
+
+  test('redirect params: can use legacy param format (scope string)', () => {
+    const auth = new Auth({
+      issuer: 'https://foo/oauth2/default',
+      client_id: 'foo',
+      redirect_uri: 'foo'
+    });
+    const overrides = {
+      scope: 'openid foo',
+      response_type: ['fake']
+    };
+    auth.redirect(overrides);
+    expect(mockAuthJsInstance.token.getWithRedirect).toHaveBeenCalledWith(Object.assign(overrides, {
+      scopes: ['openid', 'foo'],
+      responseType: ['fake'],
+    }));
+  });
+
+  test('redirect params: can use legacy param format (scope array)', () => {
+    const auth = new Auth({
+      issuer: 'https://foo/oauth2/default',
+      client_id: 'foo',
+      redirect_uri: 'foo'
+    });
+    const overrides = {
+      scope: ['openid', 'foo'],
+      response_type: ['fake']
+    };
+    auth.redirect(overrides);
+    expect(mockAuthJsInstance.token.getWithRedirect).toHaveBeenCalledWith(Object.assign(overrides, {
+      scopes: ['openid', 'foo'],
+      responseType: ['fake'],
+    }));
+  });
+
   test('can append the authorize request builder with additionalParams through auth.redirect', () => {
     const auth = new Auth({
       issuer: 'https://foo/oauth2/default',

--- a/packages/okta-vue/README.md
+++ b/packages/okta-vue/README.md
@@ -217,6 +217,7 @@ he most commonly used options are shown here. See [Configuration Reference](http
 - `issuer` **(required)**: The OpenID Connect `issuer`
 - `clientId` **(required)**: The OpenID Connect `client_id`
 - `redirectUri` **(required)**: Where the callback is hosted
+- `scope` *(deprecated in v1.1.1)*: Use `scopes` instead
 - `scopes` *(optional)*: Reserved or custom claims to be returned in the tokens. Defaults to `openid`, which will only return the `sub` claim. To obtain more information about the user, use `openid profile`. For a list of scopes and claims, please see [Scope-dependent claims](https://developer.okta.com/standards/OIDC/index.html#scope-dependent-claims-not-always-returned) for more information.
 - `responseType` *(optional)*: Desired token grant types. Default: `['id_token', 'token']`. For PKCE flow, this should be left undefined or set to `['code']`.
 - `pkce` *(optional)* - If `true`, PKCE flow will be used

--- a/packages/okta-vue/README.md
+++ b/packages/okta-vue/README.md
@@ -50,7 +50,7 @@ Vue.use(Auth, {
   issuer: 'https://{yourOktaDomain}.com/oauth2/default',
   clientId: '{clientId}',
   redirectUri: 'http://localhost:{port}/implicit/callback',
-  scope: 'openid profile email'
+  scopes: ['openid', 'profile', 'email']
 })
 
 ```
@@ -217,7 +217,7 @@ he most commonly used options are shown here. See [Configuration Reference](http
 - `issuer` **(required)**: The OpenID Connect `issuer`
 - `clientId` **(required)**: The OpenID Connect `client_id`
 - `redirectUri` **(required)**: Where the callback is hosted
-- `scope` *(optional)*: Reserved or custom claims to be returned in the tokens
+- `scopes` *(optional)*: Reserved or custom claims to be returned in the tokens. Defaults to `openid`, which will only return the `sub` claim. To obtain more information about the user, use `openid profile`. For a list of scopes and claims, please see [Scope-dependent claims](https://developer.okta.com/standards/OIDC/index.html#scope-dependent-claims-not-always-returned) for more information.
 - `responseType` *(optional)*: Desired token grant types. Default: `['id_token', 'token']`. For PKCE flow, this should be left undefined or set to `['code']`.
 - `pkce` *(optional)* - If `true`, PKCE flow will be used
 - `autoRenew` *(optional)*:

--- a/packages/okta-vue/test/e2e/harness/src/router/index.js
+++ b/packages/okta-vue/test/e2e/harness/src/router/index.js
@@ -17,7 +17,7 @@ let config = {
   redirectUri,
   pkce,
   clientId: process.env.CLIENT_ID,
-  scope: 'openid profile email',
+  scopes: ['openid', 'profile', 'email'],
   testing: {
     disableHttpsCheck: false
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [x] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 246583


## What is the new behavior?
The main config for authJS has been previously normalized. This PR normalizes the config used only by the "get token" flow. Specifically, `responseType` and `scopes`.  We have been allowing a parameter named `scope` which is a (space separated string). and a parameter named `response_type` (also a space separated string). These match OIDC url parameters, but not our preferred internal config format.

While maintaining compatibility, `buildConfigObject` will apply all transformations such that the final config is in our preferred format.  If an object is already in preferred format, it will pass through unchanged.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

@swiftone 
@manueltanzi-okta 