### PR TITLE
fix[oidc-middleware]: logout: emit errors outside promise chain

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,31 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "protocol": "auto",
+      "name": "oidc-middleware Jest",
+      "cwd": "${workspaceFolder}/packages/oidc-middleware",
+      "args": [
+        "node_modules/.bin/jest",
+        "--runInBand",
+        "--no-cache",
+        "${workspaceFolder}/${relativeFile}"
+      ],
+      "sourceMaps": true,
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "env": {
+
+      },
+      "sourceMapPathOverrides": {
+        "webpack:///*": "/*",
+      },
+      "disableOptimisticBPs": true
+    },
+  ]
+}

--- a/packages/oidc-middleware/src/logout.js
+++ b/packages/oidc-middleware/src/logout.js
@@ -15,12 +15,15 @@ const uuid = require('uuid');
 
 const logout = module.exports;
 
-const makeErrorHandler = emitter => err => { 
-  if (err.type) { 
-    emitter.emit('error', `${err.type} - ${err.text}`);
-  } else {
-    emitter.emit('error', err);
-  }
+const makeErrorHandler = emitter => err => {
+  // Emit the errors outside the promise chain so they can be received by event listeners
+  setTimeout(function() {
+    if (err.type) { 
+      emitter.emit('error', `${err.type} - ${err.text}`);
+    } else {
+      emitter.emit('error', err);
+    }
+  }, 1);
 };
 
 const makeAuthorizationHeader = ({ client_id, client_secret }) => 

--- a/packages/oidc-middleware/test/unit/logout.spec.js
+++ b/packages/oidc-middleware/test/unit/logout.spec.js
@@ -1,0 +1,163 @@
+
+jest.mock('node-fetch');
+const nodeFetch = require('node-fetch');
+
+jest.mock('uuid', () => { return {}; });
+const uuid = require('uuid');
+
+const { forceLogoutAndRevoke } = require('../../src/logout');
+
+
+describe('logout', () => {
+  let fetchResponse;
+  let fetch;
+  let context;
+  let logout;
+  let req;
+  let res;
+
+  // Test values
+  const issuer = 'testIssuer';
+  const client_id = 'testClientId';
+  const client_secret = 'testSecret';
+  const id_token = 'testIdToken';
+  const logoutRedirectUri = 'testLogoutUri';
+  const mockState = 'fake-state';
+  const sessionKey = 'fake-session-key';
+
+  // Expected values
+  const expectedAuthHeader = 'Basic dGVzdENsaWVudElkOnRlc3RTZWNyZXQ=';
+  const expectedUri = `${issuer}/v1/logout?state=${mockState}&id_token_hint=${id_token}&post_logout_redirect_uri=${logoutRedirectUri}`;
+
+  beforeEach(() => {
+    fetchResponse = Promise.resolve('OK');
+    fetch = jest.fn().mockImplementation(() => {
+      return fetchResponse;
+    });
+    nodeFetch.mockImplementation(fetch);
+
+    uuid.v4 = jest.fn().mockReturnValue(mockState);
+
+    context = {
+      options: {
+        issuer,
+        client_id,
+        client_secret,
+        logoutRedirectUri,
+        sessionKey
+      },
+      emitter: {
+        emit: jest.fn().mockImplementation(() => {
+          throw new Error('Unexpected error');
+        })
+      }
+    };
+    logout = forceLogoutAndRevoke(context);
+
+    req = {
+      session: {},
+      userContext: {
+        tokens: {
+          id_token
+        }
+      }
+    };
+    res = {
+      redirect: jest.fn()
+    };
+  });
+
+  describe('revoke tokens', () => {
+    it('revokes refresh_token', async () => {
+      const tokenVal = 'sometoken';
+      const tokenType = 'refresh_token';
+      req.userContext.tokens[tokenType] = tokenVal;
+      await logout(req, res);
+      expect(fetch).toHaveBeenCalledWith(`${issuer}/v1/revoke`,{
+        body: `token=${tokenVal}&token_type_hint=${tokenType}`, 
+        headers: {
+          accepts: 'application/json',
+          authorization: expectedAuthHeader,
+          'content-type': 'application/x-www-form-urlencoded'
+        }, 
+        'method': 'POST'
+      })
+    });
+
+    it('revokes access_token', async () => {
+      const tokenVal = 'sometoken';
+      const tokenType = 'access_token';
+      req.userContext.tokens[tokenType] = tokenVal;
+      await logout(req, res);
+      expect(fetch).toHaveBeenCalledWith(`${issuer}/v1/revoke`,{
+        body: `token=${tokenVal}&token_type_hint=${tokenType}`, 
+        headers: {
+          accepts: 'application/json',
+          authorization: expectedAuthHeader,
+          'content-type': 'application/x-www-form-urlencoded'
+        }, 
+        'method': 'POST'
+      })
+    });
+
+    it('revokes both refresh_token and access_token', async () => {
+      const tokenVal = 'sometoken';
+      req.userContext.tokens['refresh_token'] = tokenVal;
+      req.userContext.tokens['access_token'] = tokenVal;
+      await logout(req, res);
+      expect(fetch).toHaveBeenNthCalledWith(1, `${issuer}/v1/revoke`,{
+        body: `token=${tokenVal}&token_type_hint=refresh_token`, 
+        headers: {
+          accepts: 'application/json',
+          authorization: expectedAuthHeader,
+          'content-type': 'application/x-www-form-urlencoded'
+        }, 
+        'method': 'POST'
+      });
+      expect(fetch).toHaveBeenNthCalledWith(2, `${issuer}/v1/revoke`,{
+        body: `token=${tokenVal}&token_type_hint=access_token`, 
+        headers: {
+          accepts: 'application/json',
+          authorization: expectedAuthHeader,
+          'content-type': 'application/x-www-form-urlencoded'
+        }, 
+        'method': 'POST'
+      })
+    });
+  });
+
+  describe('redirect', () => {
+    it('redirects to the logout endpoint, passing id_token', async () => {
+      await logout(req, res);
+      expect(res.redirect).toHaveBeenCalledWith(expectedUri);
+    });
+
+    it('will redirect event if revoke fails', async () => {
+      jest.useFakeTimers();
+
+      // In the real world, the emitter will throw
+      context.emitter.emit.mockImplementation((type, message) => {
+        throw new Error(message);
+      })
+
+      // Setup token revoke to fail
+      const errorVal = 'NOT OK';
+      fetchResponse = Promise.reject(errorVal);
+      req.userContext.tokens['refresh_token'] = 'does not matter';
+      await logout(req, res); // should not throw
+      expect(res.redirect).toHaveBeenCalledWith(expectedUri); // ensure redirect was called
+
+      // prevent exception from being thrown
+      context.emitter.emit.mockImplementation(() => {});
+      jest.runAllTimers();
+      expect(context.emitter.emit).toHaveBeenCalledWith('error', errorVal); // ensure error was emitted
+    });
+  });
+
+  describe('session', () => {
+    it('sets the session object', async () => {
+      await logout(req, res);
+      expect(req.session[sessionKey]).toEqual({ state: mockState });
+    })
+  })
+})


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
If an error occurs during logout with token revoke, the redirect will not occur, the user will not be logged out, and the client will appear to be hung. The server will see no error event.

Issue Number: 257188


## What is the new behavior?

Errors are now emitted after a brief delay. This will allow the promise chain to complete successfully and the logout redirect to occur without interruption and also allow the emitted error to be received by the app server (as it is no longer captured by the promise chain)

Since the current behavior is suppressing errors from being bubbled up properly, this fix will cause previously unseen errors to now be visible to the app server. 

## Does this PR introduce a breaking change?
- [] Yes
- [x] No

## Other information

## Reviewers

