### PR TITLE
fix[okta-angular]: Fixes DI provider factory bug resolves #670

### DIFF
--- a/packages/okta-angular/src/okta/services/okta.service.ts
+++ b/packages/okta-angular/src/okta/services/okta.service.ts
@@ -40,6 +40,13 @@ export class OktaAuthService {
 
     constructor(@Inject(OKTA_CONFIG) private auth: OktaConfig, private router: Router) {
       this.observers = [];
+      
+      /**
+       * Extract the OKTA_CONFIG if passed as array from Provider factory.
+       */
+      if(Array.isArray(auth) && auth.length > 0 && auth[0].issuer){
+        auth = auth[0];
+      }
 
       /**
        * Cache the auth config.


### PR DESCRIPTION
Fixes parsing of array wrapped OKTA_CONFIG from Provider useFactory

Resolves: #670

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
OKTA_CONFIG from Provider with useValue works correctly.
OKTA_CONFIG from Provider with useFactory does not work as angular wraps the OKTA_CONFIG object in an array.

Issue Number: 670


## What is the new behavior?
Works with Provider useValue and useFactory.  Extracts the OKTA_CONFIG object from the array when necessary prior to extracting the configuration values.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

