### PR TITLE
refactor: remove Router dep from Security, Auth, ImplicitCallback

### DIFF
--- a/packages/okta-react/README.md
+++ b/packages/okta-react/README.md
@@ -243,18 +243,22 @@ For PKCE flow, this should be left undefined or set to `['code']`.
 ```jsx
 
 class App extends Component {
+  constructor(props) {
+    super(props);
+    this.customAuthHandler = this.customAuthHandler.bind(this);
+  }
+
   customAuthHandler() {
     // Redirect to the /login page that has a CustomLoginComponent
     this.props.history.push('/login');
   }
 
   render() {
-    const customAuthHandler = this.customAuthHandler.bind(this);
     return (
       <Security issuer='https://{yourOktaDomain}.com/oauth2/default'
                 clientId='{clientId}'
                 redirectUri={window.location.origin + '/implicit/callback'}
-                onAuthRequired={customAuthHandler} >
+                onAuthRequired={this.customAuthHandler} >
         <Route path='/login' component={CustomLoginComponent}>
         {/* some routes here */}
       </Security>

--- a/packages/okta-react/src/ImplicitCallback.js
+++ b/packages/okta-react/src/ImplicitCallback.js
@@ -11,7 +11,6 @@
  */
 
 import React, { Component } from 'react';
-import { Redirect } from 'react-router';
 import withAuth from './withAuth';
 
 export default withAuth(class ImplicitCallback extends Component {
@@ -30,14 +29,20 @@ export default withAuth(class ImplicitCallback extends Component {
     .catch(err => this.setState({ authenticated: false, error: err.toString() }));
   }
 
-  render() {
-    if (this.state.authenticated === null) {
-      return null;
-    }
+  componentDidUpdate() {
+    if (this.state.authenticated !== null) {
+      const location = this.props.auth.getFromUri();
 
-    const location = this.props.auth.getFromUri();
-    return this.state.authenticated ?
-      <Redirect to={location}/> :
-      <p>{this.state.error}</p>;
+      if (this.state.authenticated === true) {
+        window.location.assign(location);
+      }
+    }
+  }
+
+  render() {
+    if (this.state.error) {
+      return <p>{this.state.error}</p>;
+    }
+    return null;
   }
 });

--- a/packages/okta-react/src/SecureRoute.js
+++ b/packages/okta-react/src/SecureRoute.js
@@ -14,11 +14,12 @@ import React, { Component } from 'react';
 import { Route } from 'react-router';
 import withAuth from './withAuth';
 
-
 class RenderWrapper extends Component {
   checkAuthentication() {
     if (this.props.authenticated === false) {
-      this.props.login();
+      const history = this.props.history;
+      const fromUri = history.createHref(history.location);
+      this.props.login(fromUri);
     }
   }
 
@@ -73,6 +74,7 @@ class SecureRoute extends Component {
         component={this.props.component}
         render={this.props.render}
         renderProps={renderProps}
+        history={renderProps.history}
       />
     );
   }

--- a/packages/okta-react/src/Security.js
+++ b/packages/okta-react/src/Security.js
@@ -11,7 +11,6 @@
  */
 
 import React, { Component } from 'react';
-import { withRouter } from 'react-router';
 import PropTypes from 'prop-types';
 import Auth from './Auth';
 
@@ -40,4 +39,4 @@ class Security extends Component {
   }
 }
 
-export default withRouter(Security);
+export default Security;

--- a/packages/okta-react/test/e2e/harness/src/App.js
+++ b/packages/okta-react/test/e2e/harness/src/App.js
@@ -11,7 +11,8 @@
  */
 
 import React, { Component } from 'react';
-import { BrowserRouter as Router, Route } from 'react-router-dom';
+import { Route } from 'react-router-dom';
+import { withRouter } from 'react-router';
 import { Security, SecureRoute, ImplicitCallback, Auth } from '@okta/okta-react';
 import Home from './Home';
 import Protected from './Protected';
@@ -23,18 +24,22 @@ if (!Auth) {
 }
 
 class App extends Component {
+  onAuthRequired() {
+    this.props.history.push('/login')
+  }
+
   render() {
      /* global process */
     const { ISSUER, CLIENT_ID } = process.env;
     const { pkce, redirectUri } = this.props;
+    const onAuthRequired = this.onAuthRequired.bind(this);
     return (
       <React.StrictMode>
-        <Router>
           <Security issuer={ISSUER}
                     clientId={CLIENT_ID}
                     disableHttpsCheck={true}
                     redirectUri={redirectUri}
-                    onAuthRequired={({history}) => history.push('/login')}
+                    onAuthRequired={onAuthRequired}
                     pkce={pkce}>
             <Route path='/' component={Home}/>
             <Route path='/login' component={CustomLogin}/>
@@ -43,10 +48,9 @@ class App extends Component {
             <Route path='/implicit/callback' component={ImplicitCallback} />
             <Route path='/pkce/callback' component={ImplicitCallback} />
           </Security>
-        </Router>
       </React.StrictMode>
     );
   }
 }
 
-export default App;
+export default withRouter(App);

--- a/packages/okta-react/test/e2e/harness/src/App.js
+++ b/packages/okta-react/test/e2e/harness/src/App.js
@@ -24,6 +24,11 @@ if (!Auth) {
 }
 
 class App extends Component {
+  constructor(props) {
+    super(props);
+    this.onAuthRequired = this.onAuthRequired.bind(this);
+  }
+
   onAuthRequired() {
     this.props.history.push('/login')
   }
@@ -32,14 +37,13 @@ class App extends Component {
      /* global process */
     const { ISSUER, CLIENT_ID } = process.env;
     const { pkce, redirectUri } = this.props;
-    const onAuthRequired = this.onAuthRequired.bind(this);
     return (
       <React.StrictMode>
           <Security issuer={ISSUER}
                     clientId={CLIENT_ID}
                     disableHttpsCheck={true}
                     redirectUri={redirectUri}
-                    onAuthRequired={onAuthRequired}
+                    onAuthRequired={this.onAuthRequired}
                     pkce={pkce}>
             <Route path='/' component={Home}/>
             <Route path='/login' component={CustomLogin}/>

--- a/packages/okta-react/test/e2e/harness/src/index.js
+++ b/packages/okta-react/test/e2e/harness/src/index.js
@@ -15,6 +15,7 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
 import registerServiceWorker from './registerServiceWorker';
+import { BrowserRouter as Router } from 'react-router-dom';
 
 // To perform end-to-end PKCE flow we must be configured on both ends: when the login is initiated, and on the callback
 // The login page is loaded with a query param. This will select a unique callback url
@@ -23,5 +24,10 @@ const url = new URL(window.location.href);
 const pkce = !!url.searchParams.get('pkce') || url.pathname.indexOf('pkce/callback') >= 0;
 const redirectUri = window.location.origin + (pkce ? '/pkce/callback' : '/implicit/callback');
 
-ReactDOM.render(<App pkce={pkce} redirectUri={redirectUri} />, document.getElementById('root'));
+ReactDOM.render(
+  <Router>
+    <App pkce={pkce} redirectUri={redirectUri} />
+  </Router>
+, document.getElementById('root'));
+
 registerServiceWorker();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [] Other... Please describe:

## What is the current behavior?
Currently there is a dependency on react-router within `Security`, 'Auth` and `ImplicitCallback`
Issue Number: N/A


## What is the new behavior?
Only `SecureRoute` has a dependency on router

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

The signature for `onAuthRequired` has changed and the `history` object is no longer passed to the callback function.

`getFromUri()` and `setFromUri()` now set and return the URI as a string (rather than an object)

## Other information


## Reviewers
@swiftone 
@shuowu-okta 
