### PR TITLE
fix[okta-react]: Fixes bug where LoginCallback throws error

### DIFF
--- a/packages/okta-react/src/LoginCallback.js
+++ b/packages/okta-react/src/LoginCallback.js
@@ -21,7 +21,7 @@ const LoginCallback = () => {
   }, [authService]);
 
   if(authState.error) { 
-    return <p>${authState.error}</p>;
+    return <p>{authState.error.toString()}</p>;
   }
 
   return null;


### PR DESCRIPTION
Fixes bug where LoginCallback tries to render the error object as a react child.

When the login-callback component receives an error it tries to render the object rather than the error message.

Turns out this is failing tests, Im still learning to code so would appreciate guidance

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When the authentication returns an error, the LoginCallback components attempts to render the error object, resulting in a react error "Objects are not valid as a React child"
Issue Number: N/A


## What is the new behavior?

The component renders the error message instead

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

