### PR TITLE
fix[okta-react]: Remove <div> from <Security> tag

### DIFF
--- a/packages/okta-react/src/Security.js
+++ b/packages/okta-react/src/Security.js
@@ -29,9 +29,7 @@ const Security = (props) => {
 
   return (
     <OktaContext.Provider value={ { authService, authState } }>
-      <div className={props.className}>
-        {props.children}
-      </div>
+      {props.children}
     </OktaContext.Provider>
   );
 };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently the `<Security>` provider is adding an additional `<div>` tag to the DOM. This can be problematic  for `grid` and `flex` layouts.

## What is the new behavior?
This PR removes this element, as it doesn't seem to serve a purpose.

## Does this PR introduce a breaking change?
- [x] Yes
- [] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Should someone be relying on this feature, they will need to wrap `<Security>` like so:

```
<div>
  <Security>
    ...
  </Security>
</div>
```

## Other information


## Reviewers

