### PR TITLE
updates to auth-js 3

### DIFF
--- a/packages/okta-react/CHANGELOG.md
+++ b/packages/okta-react/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 3.0.0
+
+### Breaking Changes
+- Uses/requires @okta/okta-auth-js 3.x
+  - Notably, this means `pkce` now defaults to `true` 
+    - See the [@okta/okta-auth-js README regarding PKCE OAuth2 Flow](https://github.com/okta/okta-auth-js#pkce-oauth-20-flow) for requirements
+    - The settings for the Application on your Okta Admin Dashboard must include allowing PKCE
+    - If you are using the (previous default) Implicit Flow, you should set `pkce: false`
+- `<Security>` no longer creates a `<div>` wrapper around its children
+  - The `className` property of `<Security>` is no longer used
+  - Existing applications that rely on this `<div>` can add it themselves as a parent or direct child of `<Security>`
+
 # 2.0.1
 
 ### Bug Fixes

--- a/packages/okta-react/README.md
+++ b/packages/okta-react/README.md
@@ -1,4 +1,4 @@
-[allowing Okta Auth SDK]: https://github.com/okta/okta-auth-js
+[Okta Auth SDK]: https://github.com/okta/okta-auth-js
 [react-router]: https://github.com/ReactTraining/react-router
 [reach-router]: https://reach.tech/router
 [higher-order component]: https://reactjs.org/docs/higher-order-components.html
@@ -308,8 +308,8 @@ These options are used by `Security` to configure the [Auth service][]. The most
 - **scopes** *(optional)* - Reserved for custom claims to be returned in the tokens. Default: `['openid', 'email', 'profile']`. For a list of scopes and claims, please see [Scope-dependent claims](https://developer.okta.com/standards/OIDC/index.html#scope-dependent-claims-not-always-returned) for more information.
 - **responseType** *(optional)* - Desired token types. Default: `['id_token', 'token']`.
   - For PKCE flow, this should be left undefined or set to `['code']`.
-- **pkce** *(optional)* - If `true` Authorization Code w/PKCE flow will be used.  See the [@okta/okta-auth-js README regarding PKCE OAuth2 Flow](https://github.com/okta/okta-auth-js#pkce-oauth-20-flow) for requirements, including any required polyfills.  If you are using the Implicit Flow, you should set `pkce: false`. Default: `true`.
-- **onAuthRequired** *(optional)* - callback function. Called when authentication is required. If this is not supplied, `okta-react` redirects to Okta. This callback will receive `auth` as the first function parameter. This is triggered when:
+- **pkce** *(optional)* - If `true`, Authorization Code w/PKCE Flow will be used.  See the [@okta/okta-auth-js README regarding PKCE OAuth2 Flow](https://github.com/okta/okta-auth-js#pkce-oauth-20-flow) for requirements, including any required polyfills.  If you are using the Implicit Flow, you should set `pkce: false`. Default: `true`.
+- **onAuthRequired** *(optional)* - callback function. Called when authentication is required. If this is not supplied, `okta-react` redirects to Okta. This callback will receive `authService` as the first function parameter. This is triggered when:
     1. [login](#authserviceloginfromuri-additionalparams) is called
     2. A `SecureRoute` is accessed without authentication
 - **onSessionExpired** *(optional)* - callback function. Called when the Okta SSO session has expired or was ended outside of the application. This SDK adds a default handler which will call [login](#authserviceloginfromuri-additionalparams) to initiate a login flow. Passing a function here will disable the default handler.
@@ -317,9 +317,7 @@ These options are used by `Security` to configure the [Auth service][]. The most
 - **tokenManager** *(optional)*: An object containing additional properties used to configure the internal token manager. See [AuthJS TokenManager](https://github.com/okta/okta-auth-js#the-tokenmanager) for more detailed information.
   - `autoRenew` *(optional)*:
   By default, the library will attempt to renew expired tokens. When an expired token is requested by the library, a renewal request is executed to update the token. If you wish to  to disable auto renewal of tokens, set autoRenew to false.
-
   - `secure`: If `true` then only "secure" https cookies will be stored. This option will prevent cookies from being stored on an HTTP connection. This option is only relevant if `storage` is set to `cookie`, or if the client browser does not support `localStorage` or `sessionStorage`, in which case `cookie` storage will be used.
-
   - `storage` *(optional)*:
     Specify the type of storage for tokens.
     The types are:

--- a/packages/okta-react/README.md
+++ b/packages/okta-react/README.md
@@ -1,4 +1,4 @@
-[Okta Auth SDK]: https://github.com/okta/okta-auth-js
+[allowing Okta Auth SDK]: https://github.com/okta/okta-auth-js
 [react-router]: https://github.com/ReactTraining/react-router
 [reach-router]: https://reach.tech/router
 [higher-order component]: https://reactjs.org/docs/higher-order-components.html
@@ -307,8 +307,8 @@ These options are used by `Security` to configure the [Auth service][]. The most
 - **postLogoutRedirectUri** | Specify the url where the browser should be redirected after [logout](#authservicelogouturi). This url must be added to the list of `Logout redirect URIs` on the application's `General Settings` tab.
 - **scopes** *(optional)* - Reserved for custom claims to be returned in the tokens. Default: `['openid', 'email', 'profile']`. For a list of scopes and claims, please see [Scope-dependent claims](https://developer.okta.com/standards/OIDC/index.html#scope-dependent-claims-not-always-returned) for more information.
 - **responseType** *(optional)* - Desired token types. Default: `['id_token', 'token']`.
-For PKCE flow, this should be left undefined or set to `['code']`.
-- **pkce** *(optional)* - If `true`, PKCE flow will be used
+  - For PKCE flow, this should be left undefined or set to `['code']`.
+- **pkce** *(optional)* - If `true` Authorization Code w/PKCE flow will be used.  See the [@okta/okta-auth-js README regarding PKCE OAuth2 Flow](https://github.com/okta/okta-auth-js#pkce-oauth-20-flow) for requirements, including any required polyfills.  If you are using the Implicit Flow, you should set `pkce: false`. Default: `true`.
 - **onAuthRequired** *(optional)* - callback function. Called when authentication is required. If this is not supplied, `okta-react` redirects to Okta. This callback will receive `auth` as the first function parameter. This is triggered when:
     1. [login](#authserviceloginfromuri-additionalparams) is called
     2. A `SecureRoute` is accessed without authentication

--- a/packages/okta-react/package.json
+++ b/packages/okta-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okta/okta-react",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "React support for Okta",
   "main": "./dist/index.js",
   "scripts": {
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/okta/okta-oidc-js#readme",
   "dependencies": {
     "@okta/configuration-validation": "^0.4.1",
-    "@okta/okta-auth-js": "^2.11.2",
+    "@okta/okta-auth-js": "^3.0.0",
     "babel-runtime": "^6.26.0",
     "prop-types": "^15.5.10"
   },

--- a/packages/okta-react/src/AuthService.js
+++ b/packages/okta-react/src/AuthService.js
@@ -54,6 +54,7 @@ class AuthService {
     this.getAccessToken = this.getAccessToken.bind(this);
     this.login = this.login.bind(this);
     this.logout = this.logout.bind(this);
+    this._convertLogoutPathToOptions = this._convertLogoutPathToOptions.bind(this);
     this.redirect = this.redirect.bind(this);
     this.emit = this.emit.bind(this);
     this.on = this.on.bind(this);
@@ -163,15 +164,11 @@ class AuthService {
   async getUser() {
     const accessToken = await this._oktaAuth.tokenManager.get('accessToken');
     const idToken = await this._oktaAuth.tokenManager.get('idToken');
-    if (accessToken && idToken) {
-      const userinfo = await this._oktaAuth.token.getUserInfo(accessToken);
-      if (userinfo.sub === idToken.claims.sub) {
-        // Only return the userinfo response if subjects match to
-        // mitigate token substitution attacks
-        return userinfo;
-      }
+    if (!accessToken || !idToken) { 
+      return idToken ? idToken.claims : undefined;
     }
-    return idToken ? idToken.claims : undefined;
+
+    return this._oktaAuth.token.getUserInfo();
   }
 
   async getIdToken() {
@@ -207,28 +204,23 @@ class AuthService {
     return this.redirect(additionalParams);
   }
 
-  async logout(options) {
-    let path = null;
-    options = options || {};
-    if (typeof options === 'string') {
-      path = options;
-      options = {};
+  _convertLogoutPathToOptions(redirectUri) { 
+    if (typeof redirectUri !== 'string') {
+      return redirectUri;
     }
+    // If a relative path was passed, convert to absolute URI
+    if (redirectUri.charAt(0) === '/') {
+      redirectUri = window.location.origin + redirectUri;
+    }
+    return {
+      postLogoutRedirectUri: redirectUri,
+    };
+  }
 
-    return this._oktaAuth.signOut(options)
-      .then(() => {
-        if (!options.postLogoutRedirectUri && !this._config.postLogoutRedirectUri) {
-          let redirectUri = path || '/';
-          // If a relative path was passed, convert to absolute URI
-          if (redirectUri.charAt(0) === '/') {
-            redirectUri = window.location.origin + redirectUri;
-          }
-          window.location.assign(redirectUri);
-        }
-      })
-      .finally( () => {
-        this.clearAuthState();
-      });
+  async logout(options={}) {
+    options = this._convertLogoutPathToOptions(options);
+    await this._oktaAuth.signOut(options);
+    this.clearAuthState();
   }
 
   async redirect(additionalParams = {}) {

--- a/packages/okta-react/src/AuthService.js
+++ b/packages/okta-react/src/AuthService.js
@@ -74,16 +74,15 @@ class AuthService {
     }
     try { 
       this._pending.handleAuthentication = true;
-      let tokens = await this._oktaAuth.token.parseFromUrl();
-      tokens = Array.isArray(tokens) ? tokens : [tokens];    
+      const {tokens} = await this._oktaAuth.token.parseFromUrl();
 
-      for (let token of tokens) {
-        if (token.idToken) {
-          this._oktaAuth.tokenManager.add('idToken', token);
-        } else if (token.accessToken) {
-          this._oktaAuth.tokenManager.add('accessToken', token);
-        }
+      if (tokens.idToken) {
+        this._oktaAuth.tokenManager.add('idToken', tokens.idToken);
       }
+      if (tokens.accessToken) {
+        this._oktaAuth.tokenManager.add('accessToken', tokens.accessToken);
+      }
+
       await this.updateAuthState();
       const authState = this.getAuthState();
       if(authState.isAuthenticated) { 

--- a/packages/okta-react/src/Security.js
+++ b/packages/okta-react/src/Security.js
@@ -29,9 +29,7 @@ const Security = (props) => {
 
   return (
     <OktaContext.Provider value={ { authService, authState } }>
-      <div className={props.className}>
-        {props.children}
-      </div>
+      {props.children}
     </OktaContext.Provider>
   );
 };

--- a/packages/okta-react/test/e2e/harness/src/SessionTokenLogin.js
+++ b/packages/okta-react/test/e2e/harness/src/SessionTokenLogin.js
@@ -29,9 +29,8 @@ export default withOktaAuth(class SessionTokenLogin extends Component {
   }
 
   componentWillMount() {
-    const origin = new URL(this.props.authService._config.issuer).origin;
     this.oktaAuth = new OktaAuth({
-      url: origin
+      issuer: this.props.authService._config.issuer
     });
   }
 

--- a/packages/okta-react/test/jest/authService.test.js
+++ b/packages/okta-react/test/jest/authService.test.js
@@ -820,13 +820,13 @@ describe('AuthService', () => {
       const idToken = {
         idToken: 'fake id'
       };
-      jest.spyOn(authService._oktaAuth.token, 'parseFromUrl').mockReturnValue([accessToken, idToken]);
+      jest.spyOn(authService._oktaAuth.token, 'parseFromUrl').mockReturnValue({ tokens: { accessToken, idToken }});
       jest.spyOn(authService._oktaAuth.tokenManager, 'add');
       return authService.handleAuthentication()
         .then(() => {
           expect(authService._oktaAuth.tokenManager.add).toHaveBeenCalledTimes(2);
-          expect(authService._oktaAuth.tokenManager.add.mock.calls[0]).toEqual(['accessToken', accessToken]);
-          expect(authService._oktaAuth.tokenManager.add.mock.calls[1]).toEqual(['idToken', idToken]);
+          expect(authService._oktaAuth.tokenManager.add.mock.calls[0]).toEqual(['idToken', idToken]);
+          expect(authService._oktaAuth.tokenManager.add.mock.calls[1]).toEqual(['accessToken', accessToken]);
         });
     });
 
@@ -840,7 +840,7 @@ describe('AuthService', () => {
       jest.spyOn(authService, 'updateAuthState').mockImplementation( () => { 
         jest.spyOn(authService, 'getAuthState').mockReturnValue(mockAuthState);
       });
-      jest.spyOn(authService._oktaAuth.token, 'parseFromUrl').mockReturnValue(Promise.resolve([]));
+      jest.spyOn(authService._oktaAuth.token, 'parseFromUrl').mockReturnValue(Promise.resolve({ tokens: {} }));
       return authService.handleAuthentication()
         .then(() => {
           expect(window.location.assign).toHaveBeenCalledWith(mockLocation);
@@ -871,7 +871,7 @@ describe('AuthService', () => {
       const p1 = authService.handleAuthentication();
       const p2 = authService.handleAuthentication();
       expect(authService.updateAuthState).not.toHaveBeenCalled();
-      resolveParsePromise([]);
+      resolveParsePromise({ tokens: {} });
       return p1
         .then(() => p2) // make sure both are finished
         .then(() => {

--- a/packages/okta-react/test/jest/authService.test.js
+++ b/packages/okta-react/test/jest/authService.test.js
@@ -86,7 +86,7 @@ describe('AuthService configuration', () => {
     expect(createInstance).toThrow()
   });
 
-  it('should throw if the client_id is not provided', () => {
+  it('should throw if the clientId is not provided', () => {
     function createInstance () {
       return new AuthService({
         issuer: 'https://foo/oauth2/default'
@@ -95,32 +95,32 @@ describe('AuthService configuration', () => {
     expect(createInstance).toThrow()
   });
 
-  it('should throw if a client_id matching {clientId} is provided', () => {
+  it('should throw if a clientId matching {clientId} is provided', () => {
     function createInstance () {
       return new AuthService({
         issuer: 'https://foo/oauth2/default',
-        client_id: '{clientId}',
+        clientId: '{clientId}',
       });
     }
     expect(createInstance).toThrow()
   });
 
-  it('should throw if the redirect_uri is not provided', () => {
+  it('should throw if the redirectUri is not provided', () => {
     function createInstance () {
       return new AuthService({
         issuer: 'https://foo/oauth2/default',
-        client_id: 'foo'
+        clientId: 'foo'
       });
     }
     expect(createInstance).toThrow();
   });
 
-  it('should throw if a redirect_uri matching {redirectUri} is provided', () => {
+  it('should throw if a redirectUri matching {redirectUri} is provided', () => {
     function createInstance () {
       return new AuthService({
         issuer: 'https://foo/oauth2/default',
-        client_id: 'foo',
-        redirect_uri: '{redirectUri}'
+        clientId: 'foo',
+        redirectUri: '{redirectUri}'
       });
     }
     expect(createInstance).toThrow();
@@ -255,8 +255,8 @@ describe('AuthService', () => {
     test('defaults to passing an empty options to signOut', async () => {
       const authService = new AuthService({
         issuer: 'https://foo/oauth2/default',
-        client_id: 'foo',
-        redirect_uri: 'foo',
+        clientId: 'foo',
+        redirectUri: 'foo',
       });
       await authService.logout();
       expect(mockAuthJsInstance.signOut).toHaveBeenCalledWith({});
@@ -265,8 +265,8 @@ describe('AuthService', () => {
     test('can pass options to signOut', async () => {
       const authService = new AuthService({
         issuer: 'https://foo/oauth2/default',
-        client_id: 'foo',
-        redirect_uri: 'foo',
+        clientId: 'foo',
+        redirectUri: 'foo',
       });
       await authService.logout({ foo: 'bar' });
       expect(mockAuthJsInstance.signOut).toHaveBeenCalledWith({ foo: 'bar'});
@@ -275,8 +275,8 @@ describe('AuthService', () => {
     test('if an absolute url string is passed, it will be used as history path', async () => {
       const authService = new AuthService({
         issuer: 'https://foo/oauth2/default',
-        client_id: 'foo',
-        redirect_uri: 'foo',
+        clientId: 'foo',
+        redirectUri: 'foo',
       });
       const testPath = 'http://example.com/fake/blah';
       await authService.logout(testPath);
@@ -286,8 +286,8 @@ describe('AuthService', () => {
     test('if a relative url string is passed, it will be converted to absolute', async () => {
       const authService = new AuthService({
         issuer: 'https://foo/oauth2/default',
-        client_id: 'foo',
-        redirect_uri: 'foo',
+        clientId: 'foo',
+        redirectUri: 'foo',
       });
       const testPath = '/fake/blah';
       await authService.logout(testPath);
@@ -297,8 +297,8 @@ describe('AuthService', () => {
     test('returns a promise', async () => {
       const authService = new AuthService({
         issuer: 'https://foo/oauth2/default',
-        client_id: 'foo',
-        redirect_uri: 'foo',
+        clientId: 'foo',
+        redirectUri: 'foo',
         history: {
           push: jest.fn()
         }
@@ -314,8 +314,8 @@ describe('AuthService', () => {
       mockAuthJsInstance.signOut = jest.fn().mockReturnValue(Promise.reject(testError));
       const authService = new AuthService({
         issuer: 'https://foo/oauth2/default',
-        client_id: 'foo',
-        redirect_uri: 'foo',
+        clientId: 'foo',
+        redirectUri: 'foo',
       });
       return authService.logout()
         .catch(e => {
@@ -330,8 +330,8 @@ describe('AuthService', () => {
   test('sets the right user agent on AuthJS', () => {
     const authService = new AuthService({
       issuer: 'https://foo/oauth2/default',
-      client_id: 'foo',
-      redirect_uri: 'foo'
+      clientId: 'foo',
+      redirectUri: 'foo'
     });
     const expectedUserAgent = `${pkg.name}/${pkg.version} okta-auth-js`;
     expect(authService._oktaAuth.userAgent).toMatch(expectedUserAgent);
@@ -340,8 +340,8 @@ describe('AuthService', () => {
   test('can retrieve an accessToken from the tokenManager', async (done) => {
     const authService = new AuthService({
       issuer: 'https://foo/oauth2/default',
-      client_id: 'foo',
-      redirect_uri: 'foo'
+      clientId: 'foo',
+      redirectUri: 'foo'
     });
     const accessToken = await authService.getAccessToken();
     expect(accessToken).toBe(accessTokenParsed.accessToken);
@@ -351,8 +351,8 @@ describe('AuthService', () => {
   test('builds the authorize request with correct params', () => {
     const authService = new AuthService({
       issuer: 'https://foo/oauth2/default',
-      client_id: 'foo',
-      redirect_uri: 'foo'
+      clientId: 'foo',
+      redirectUri: 'foo'
     });
     authService.redirect();
     expect(mockAuthJsInstance.token.getWithRedirect).toHaveBeenCalledWith({
@@ -364,8 +364,8 @@ describe('AuthService', () => {
   test('can override the authorize request builder scope with config params', () => {
     const authService = new AuthService({
       issuer: 'https://foo/oauth2/default',
-      client_id: 'foo',
-      redirect_uri: 'foo',
+      clientId: 'foo',
+      redirectUri: 'foo',
       scope: ['openid', 'foo']
     });
     authService.redirect();
@@ -378,8 +378,8 @@ describe('AuthService', () => {
   test('can override the authorize request builder responseType with config params', () => {
     const authService = new AuthService({
       issuer: 'https://foo/oauth2/default',
-      client_id: 'foo',
-      redirect_uri: 'foo',
+      clientId: 'foo',
+      redirectUri: 'foo',
       response_type: ['id_token']
     });
     authService.redirect();
@@ -392,8 +392,8 @@ describe('AuthService', () => {
   test('can override the authorize request builder with redirect params', () => {
     const authService = new AuthService({
       issuer: 'https://foo/oauth2/default',
-      client_id: 'foo',
-      redirect_uri: 'foo'
+      clientId: 'foo',
+      redirectUri: 'foo'
     });
     const overrides = {
       scopes: ['openid', 'foo'],
@@ -406,8 +406,8 @@ describe('AuthService', () => {
   test('redirect params: can use legacy param format (scope string)', () => {
     const authService = new AuthService({
       issuer: 'https://foo/oauth2/default',
-      client_id: 'foo',
-      redirect_uri: 'foo'
+      clientId: 'foo',
+      redirectUri: 'foo'
     });
     const overrides = {
       scope: 'openid foo',
@@ -423,8 +423,8 @@ describe('AuthService', () => {
   test('redirect params: can use legacy param format (scope array)', () => {
     const authService = new AuthService({
       issuer: 'https://foo/oauth2/default',
-      client_id: 'foo',
-      redirect_uri: 'foo'
+      clientId: 'foo',
+      redirectUri: 'foo'
     });
     const overrides = {
       scope: ['openid', 'foo'],
@@ -440,8 +440,8 @@ describe('AuthService', () => {
   test('can append the authorize request builder with additionalParams through authService.redirect', async () => {
     const authService = new AuthService({
       issuer: 'https://foo/oauth2/default',
-      client_id: 'foo',
-      redirect_uri: 'foo'
+      clientId: 'foo',
+      redirectUri: 'foo'
     });
     await authService.redirect({foo: 'bar'});
     expect(mockAuthJsInstance.token.getWithRedirect).toHaveBeenCalledWith({
@@ -454,8 +454,8 @@ describe('AuthService', () => {
   test('can append the authorize request builder with additionalParams through authService.login', async () => {
     const authService = new AuthService({
       issuer: 'https://foo/oauth2/default',
-      client_id: 'foo',
-      redirect_uri: 'foo'
+      clientId: 'foo',
+      redirectUri: 'foo'
     });
     await authService.login('/', {foo: 'bar'});
     expect(mockAuthJsInstance.token.getWithRedirect).toHaveBeenCalledWith({

--- a/packages/okta-react/test/jest/security.test.js
+++ b/packages/okta-react/test/jest/security.test.js
@@ -7,9 +7,9 @@ import { useOktaAuth } from '../../src/OktaContext';
 
 describe('<Security />', () => {
   const VALID_CONFIG = {
-    issuer: 'https://foo/oauth2/default',
-    client_id: 'foo',
-    redirect_uri: 'https://foo'
+    issuer: 'https://example.com/oauth2/default',
+    clientId: 'foo',
+    redirectUri: 'https://example.com'
   };
   let authService;
   let initialAuthState;

--- a/packages/okta-react/yarn.lock
+++ b/packages/okta-react/yarn.lock
@@ -115,7 +115,7 @@
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@okta/configuration-validation/-/configuration-validation-0.4.1.tgz#6fa4520bc96c27b3d7aedcb0523de1fbceee9105"
 
-"@okta/okta-auth-js@3":
+"@okta/okta-auth-js@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-3.0.0.tgz#8fc9d07e3e2906f6f2506fa92a483789892110fb"
   integrity sha512-RD9R2JdNYKeg4OD6weRk/tHURVbC88L40ve2qZdbi1UrfdLyh3wlmrz5H/9H80my1t5JACZvUIR9MWnQaEapGA==

--- a/packages/okta-react/yarn.lock
+++ b/packages/okta-react/yarn.lock
@@ -115,16 +115,15 @@
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@okta/configuration-validation/-/configuration-validation-0.4.1.tgz#6fa4520bc96c27b3d7aedcb0523de1fbceee9105"
 
-"@okta/okta-auth-js@^2.11.2":
-  version "2.11.2"
-  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-2.11.2.tgz#d2d867e45eb98d453f156ec68c927bf1594277f6"
+"@okta/okta-auth-js@3":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@okta/okta-auth-js/-/okta-auth-js-3.0.0.tgz#8fc9d07e3e2906f6f2506fa92a483789892110fb"
+  integrity sha512-RD9R2JdNYKeg4OD6weRk/tHURVbC88L40ve2qZdbi1UrfdLyh3wlmrz5H/9H80my1t5JACZvUIR9MWnQaEapGA==
   dependencies:
     Base64 "0.3.0"
     cross-fetch "^3.0.0"
     js-cookie "2.2.0"
     node-cache "^4.2.0"
-    q "1.4.1"
-    reqwest "2.0.5"
     tiny-emitter "1.1.0"
     xhr2 "0.1.3"
 
@@ -4576,10 +4575,6 @@ require-uncached@^1.0.3:
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
-
-reqwest@2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/reqwest/-/reqwest-2.0.5.tgz#00fb15ac4918c419ca82b43f24c78882e66039a1"
 
 resolve-cwd@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

- Updates to @okta/okta-auth-js v 3 (which defaults to PKCE)
- Removes wrapping div from `<Security>`

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- PKCE is now default. Devs will have to update their Okta Application settings and possibly polyfills for their web apps, or explicitly set `pkce: false`

- `<Security>` no longer provides a wrapping div with customizable `className`.  Devs that depend on that will have to manually provide the div as a child or parent of `<Security>`

## Other information


## Reviewers

