### PR TITLE
fix[okta-react]: check is user authenticated default behavior

### DIFF
--- a/packages/okta-react/src/AuthService.js
+++ b/packages/okta-react/src/AuthService.js
@@ -139,7 +139,7 @@ class AuthService {
       const idToken = await this.getIdToken();
 
       // Use external check, or default to isAuthenticated if either the access or id token exist
-      const isAuthenticated = this._config.isAuthenticated ? await this._config.isAuthenticated() : !! ( accessToken || idToken );
+      const isAuthenticated = this._config.isAuthenticated ? await this._config.isAuthenticated() : !! ( accessToken && idToken );
 
 
       this._pending.authStateUpdate = null;


### PR DESCRIPTION
The current implementation differs from what is mentioned in the documentation "By default, authService will consider a user authenticated if both getIdToken() and getAccessToken() return a value"
Moreover, this leads to the problems when the user doesn't have `idToken` but in the state, the `isAuthenticated` property still has value `true`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
When the user doesn't have `idToken` but in the state, the `isAuthenticated` property still has the value `true`

Issue Number: N/A


## What is the new behavior?
When the user doesn't have `idToken` or `accessToken` the state `isAuthenticated` property has the value `false`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

