### PR TITLE
fix: remove connect-ensure-login to avoid implicit req.session.returnTo change - OKTA-255316

### DIFF
--- a/packages/oidc-middleware/CHANGELOG.md
+++ b/packages/oidc-middleware/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 4.0.1
+
+### Bug Fixes
+
+- [#731](https://github.com/okta/okta-oidc-js/pull/731) 
+  - Fix redirect issue after login 
+  - Remove dependency `connect-ensure-login`
+
 # 4.0.0
 
 ### Breaking Changes

--- a/packages/oidc-middleware/package.json
+++ b/packages/oidc-middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okta/oidc-middleware",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "OpenId Connect middleware for authorization code flows",
   "repository": "https://github.com/okta/okta-oidc-js",
   "homepage": "https://github.com/okta/okta-oidc-js/tree/master/packages/oidc-middleware",

--- a/packages/oidc-middleware/package.json
+++ b/packages/oidc-middleware/package.json
@@ -35,7 +35,6 @@
   "dependencies": {
     "@okta/configuration-validation": "^0.4.1",
     "body-parser": "^1.18.2",
-    "connect-ensure-login": "^0.1.1",
     "csurf": "^1.9.0",
     "express": "^4.16.3",
     "lodash": "^4.17.5",

--- a/packages/oidc-middleware/src/ExpressOIDC.js
+++ b/packages/oidc-middleware/src/ExpressOIDC.js
@@ -87,8 +87,7 @@ module.exports = class ExpressOIDC extends EventEmitter {
           path: '/login'
         },
         loginCallback: {
-          path: '/authorization-code/callback',
-          afterCallback: '/'
+          path: '/authorization-code/callback'
         },
         logout: {
           path: '/logout'

--- a/packages/oidc-middleware/src/connectUtil.js
+++ b/packages/oidc-middleware/src/connectUtil.js
@@ -86,10 +86,16 @@ connectUtil.createLoginCallbackHandler = context => {
   const customHandler = routes.loginCallback.handler;
 
   if (!customHandler) {
-    return passport.authenticate('oidc', {
-      successReturnToOrRedirect: routes.loginCallback.afterCallback,
-      failureRedirect: routes.loginCallback.failureRedirect
-    });
+    // Passport successReturnToOrRedirect always try req.session.returnTo first if it's assigned
+    // Use successRedirect field if afterCallback url is explicitly set in config
+    const redirectOptions = { failureRedirect: routes.loginCallback.failureRedirect };
+    if (routes.loginCallback.afterCallback) {
+      redirectOptions.successRedirect = routes.loginCallback.afterCallback;
+    } else {
+      redirectOptions.successReturnToOrRedirect = '/';
+    }
+
+    return passport.authenticate('oidc', redirectOptions);
   }
 
   const customHandlerArity = customHandler.length;

--- a/packages/oidc-middleware/yarn.lock
+++ b/packages/oidc-middleware/yarn.lock
@@ -1112,11 +1112,6 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-connect-ensure-login@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/connect-ensure-login/-/connect-ensure-login-0.1.1.tgz#174dcc51243b9eac23f8d98215aeb6694e2e8a12"
-  integrity sha1-F03MUSQ7nqwj+NmCFa62aU4uihI=
-
 content-disposition@0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.3.tgz#e130caf7e7279087c5616c2007d0485698984fbd"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently `oidc-middleware` use unmaintained package `connect-ensure-login` as dependency, which implicitly changes `req.session.returnTo` value to `req.orginUrl || req.url`. 
It cause [loginCallback.afterCallback](https://github.com/okta/okta-oidc-js/tree/master/packages/oidc-middleware#customizing-routes) URL cannot be properly consumed by [passport](https://github.com/jaredhanson/passport/blob/master/lib/middleware/authenticate.js#L257)

Issue Number: #209 


## What is the new behavior?
Remove `oidc-middleware`, then reimplement `oidcUtil.ensureAuthenticated` function w/o changing 'req.session`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
[connect-ensure-login](https://github.com/jaredhanson/connect-ensure-login/blob/master/lib/ensureLoggedIn.js#L34)

## Reviewers
@aarongranick-okta 
