### PR TITLE
reverts okta-react isAuthenticated change

### DIFF
--- a/packages/okta-react/CHANGELOG.md
+++ b/packages/okta-react/CHANGELOG.md
@@ -1,8 +1,3 @@
-# 3.0.1
-
-### Bug Fixes 
-- `authState.isAuthenticated` was still `true` if one of `idToken` and `accessToken` had expired, now it is `false` if either is not valid
-
 # 3.0.0
 
 ### Breaking Changes

--- a/packages/okta-react/package.json
+++ b/packages/okta-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okta/okta-react",
-  "version": "3.0.1",
+  "version": "3.0.0",
   "description": "React support for Okta",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/okta-react/src/AuthService.js
+++ b/packages/okta-react/src/AuthService.js
@@ -139,7 +139,7 @@ class AuthService {
       const idToken = await this.getIdToken();
 
       // Use external check, or default to isAuthenticated if either the access or id token exist
-      const isAuthenticated = this._config.isAuthenticated ? await this._config.isAuthenticated() : !! ( accessToken && idToken );
+      const isAuthenticated = this._config.isAuthenticated ? await this._config.isAuthenticated() : !! ( accessToken || idToken );
 
 
       this._pending.authStateUpdate = null;

--- a/packages/okta-react/test/jest/authService.test.js
+++ b/packages/okta-react/test/jest/authService.test.js
@@ -604,7 +604,7 @@ describe('AuthService', () => {
       });
     });
 
-    it('emits an authState of isAuthenticated when the TokenManager only returns an access token', async () => { 
+    it('emits an authState of isAuthenticated when the TokenManager returns an access token', async () => { 
       const authService = new AuthService({
         issuer: 'https://foo/oauth2/default',
         clientId: 'foo',
@@ -619,14 +619,14 @@ describe('AuthService', () => {
       authService.updateAuthState();
       return wasCalled.then( authState => { 
         expect(authState).toEqual({ 
-          isAuthenticated: false, 
+          isAuthenticated: true, 
           idToken: null,
           accessToken: 'i am a fake access token',
         });
       });
     });
 
-    it('emits an authState of isAuthenticated when the TokenManager only returns an id token', async () => { 
+    it('emits an authState of isAuthenticated when the TokenManager returns an id token', async () => { 
       const authService = new AuthService({
         issuer: 'https://foo/oauth2/default',
         clientId: 'foo',
@@ -641,30 +641,9 @@ describe('AuthService', () => {
       authService.updateAuthState();
       return wasCalled.then( authState => { 
         expect(authState).toEqual({ 
-          isAuthenticated: false, 
-          idToken: 'i am a fake id token',
-          accessToken: null,
-        });
-      });
-    });
-
-    it('emits an authState where isAuthenticated is true when the the TokenManager returns both access token and id token', async () => { 
-      const authService = new AuthService({
-        issuer: 'https://foo/oauth2/default',
-        clientId: 'foo',
-        redirectUri: 'https://foo/redirect',
-      });
-      
-      let resolve;
-      const wasCalled = new Promise( (res) => resolve = res );
-      authService.on('authStateChange', authState => resolve(authState) );
-      
-      authService.updateAuthState();
-      return wasCalled.then( authState => { 
-        expect(authState).toEqual({ 
           isAuthenticated: true, 
           idToken: 'i am a fake id token',
-          accessToken: 'i am a fake access token',
+          accessToken: null,
         });
       });
     });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [X] Other... Please describe:

Revert earlier merged-but-not-published PR (#723)

## What is the current behavior?

Issue Number: #721


## What is the new behavior?

Restores original behavior of `isAuthenticated: true` if EITHER of the tokens exists

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Discussion continues on the core issue (see #721 for details)

## Reviewers

