### PR TITLE
Maintains any error message if LoginCallback has an error

### DIFF
--- a/packages/okta-react/CHANGELOG.md
+++ b/packages/okta-react/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ### Features
 
-- `<LoginCallback/>` now accepts an optional `errorComponent` prop that accepts a component that can be passed an `error` object.
+- [#738] `<LoginCallback/>` now accepts an optional `errorComponent` prop that accepts a component that can be passed an `error` object.
   - By default `<LoginCallback/>` will render with the `<OktaError/>` component
 
 ### Bug Fixes
 
 - `<LoginCallback>` now triggers only after `authState.isPending` is false, removing the problem of as error message from parsing the tokens from the url being cleared by the pending `authState` determination. See [#719](https://github.com/okta/okta-oidc-js/issues/719)
-- `<Security>` now memoizes if it creates an instance of `AuthService` so as to not create new instances on re-renders
+- [#738] `<Security>` now memoizes if it creates an instance of `AuthService` so as to not create new instances on re-renders
 
 # 3.0.0
 

--- a/packages/okta-react/CHANGELOG.md
+++ b/packages/okta-react/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Bug Fixes
 
 - `<LoginCallback>` now triggers only after `authState.isPending` is false, removing the problem of as error message from parsing the tokens from the url being cleared by the pending `authState` determination. See [#719](https://github.com/okta/okta-oidc-js/issues/719)
+- `<Security>` now memoizes if it creates an instance of `AuthService` so as to not create new instances on re-renders
 
 # 3.0.0
 

--- a/packages/okta-react/CHANGELOG.md
+++ b/packages/okta-react/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Pending
+
+### Features
+
+- `<LoginCallback/>` now accepts an optional `errorComponent` prop that accepts a component that can be passed an `error` object.
+  - By default `<LoginCallback/>` will render with the `<OktaError/>` component
+
+### Bug Fixes
+
+- `<LoginCallback>` now triggers only after `authState.isPending` is false, removing the problem of as error message from parsing the tokens from the url being cleared by the pending `authState` determination. See [#719](https://github.com/okta/okta-oidc-js/issues/719)
+
 # 3.0.1
 
 ### Bug Fixes 

--- a/packages/okta-react/README.md
+++ b/packages/okta-react/README.md
@@ -76,7 +76,7 @@ npm install --save @okta/okta-react
 `okta-react` provides the necessary tools to build an integration with most common React-based SPA routers.
 
 - [Security](#security) - Allows you to supply your OpenID Connect client [configuration](#configuration-options). Includes React context providers to allow the use of the [useOktaAuth](#useoktaauth) React Hook, or the [withOktaAuth](#useoktaauth) Higher Order Component wrapper.
-- [LoginCallback](#logincallback) - A simple component which handles the login callback when the user is redirected back to the application from the Okta login site.
+- [LoginCallback](#logincallback) - A simple component which handles the login callback when the user is redirected back to the application from the Okta login site.  `<LoginCallback>` accepts an optional prop `errorComponent` that will be used to format the output for any error in handling the callback.  This component will be passed an `error` prop that is an error describing the problem.  (see the `<OktaError>` component for the default rendering)
 
 Users of routers other than `react-router` can use [useOktaAuth](#useoktaauth) to see if a `authState.isPending` is false and `authState.isAuthenticated` is true.  If both are false, you can send them to login via `authService.login(...)`.  See the implementation of `<LoginCallback>` as an example.
 

--- a/packages/okta-react/src/AuthService.js
+++ b/packages/okta-react/src/AuthService.js
@@ -127,7 +127,7 @@ class AuthService {
     // create a promise to return in case of multiple parallel requests
     this._pending.authStateUpdate = {};
     this._pending.authStateUpdate.promise  = new Promise( (resolve) => {
-      // Promise can only resolve any error is in the resolve value
+      // Promise can only resolve, any error is in the resolve value
       // and uncaught exceptions make Front SDKs angry
       this._pending.authStateUpdate.resolve = resolve;
     });
@@ -140,7 +140,6 @@ class AuthService {
 
       // Use external check, or default to isAuthenticated if either the access or id token exist
       const isAuthenticated = this._config.isAuthenticated ? await this._config.isAuthenticated() : !! ( accessToken && idToken );
-
 
       this._pending.authStateUpdate = null;
       this.emitAuthState({ 

--- a/packages/okta-react/src/LoginCallback.js
+++ b/packages/okta-react/src/LoginCallback.js
@@ -12,16 +12,23 @@
 
 import React, { useEffect } from 'react';
 import { useOktaAuth } from './OktaContext';
+import OktaError from './OktaError';
 
-const LoginCallback = () => { 
+const LoginCallback = ({ errorComponent}) => { 
   const { authService, authState } = useOktaAuth();
+  const authStateReady = !authState.isPending;
+
+  let ErrorReporter = errorComponent || OktaError;
 
   useEffect( () => {
-    authService.handleAuthentication();
-  }, [authService]);
+    if( authStateReady ) { // wait until initial check is done so it doesn't wipe any error
+      authService.handleAuthentication();
+    }
+  }, [authService, authStateReady]);
 
-  if(authState.error) { 
-    return <p>{authState.error.toString()}</p>;
+  if(authStateReady && authState.error) { 
+    // return errorReporter(authState.error);
+    return <ErrorReporter error={authState.error}/>;
   }
 
   return null;

--- a/packages/okta-react/src/LoginCallback.js
+++ b/packages/okta-react/src/LoginCallback.js
@@ -27,7 +27,6 @@ const LoginCallback = ({ errorComponent}) => {
   }, [authService, authStateReady]);
 
   if(authStateReady && authState.error) { 
-    // return errorReporter(authState.error);
     return <ErrorReporter error={authState.error}/>;
   }
 

--- a/packages/okta-react/src/OktaError.js
+++ b/packages/okta-react/src/OktaError.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2020-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import React from 'react';
+
+const OktaError = ({ error }) => { 
+  if(error.name && error.message) { 
+    return <p>{error.name}: {error.message}</p>;
+  }
+  return <p>Error: {error.toString()}</p>;
+};
+
+export default OktaError;

--- a/packages/okta-react/src/Security.js
+++ b/packages/okta-react/src/Security.js
@@ -10,19 +10,25 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import AuthService from './AuthService';
 import OktaContext from './OktaContext';
 
 const Security = (props) => { 
 
-  const [authService] = useState( props.authService || new AuthService(props) );
-  const [authState, setAuthState] = useState(authService.getAuthState());
+  const initialAuthService = useMemo( () => { 
+    // don't keep spawning new service instances if this component rerenders
+    return props.authService || new AuthService(props);
+  }, [ props ]);
 
+  const [authService] = useState( initialAuthService );
+  const [authState, setAuthState] = useState(authService.getAuthState());
+  
   useEffect( () => { 
     const unsub = authService.on('authStateChange', () => {
       setAuthState(authService.getAuthState());
     });
+
     authService.updateAuthState(); // Trigger an initial change event to make sure authState is latest
     return unsub;
   }, [authService]);

--- a/packages/okta-react/test/jest/oktaError.test.js
+++ b/packages/okta-react/test/jest/oktaError.test.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import OktaError from '../../src/OktaError';
+import AuthSdkError from '@okta/okta-auth-js/lib/errors/AuthSdkError';
+import AuthApiError from '@okta/okta-auth-js/lib/errors/AuthApiError';
+import OAuthError from '@okta/okta-auth-js/lib/errors/OAuthError';
+
+describe('<OktaError />', () => {
+    it('renders a generic error', () => {
+      const errorMessage = 'I am a test error message';
+      const error = new Error(errorMessage);
+      const wrapper = mount(
+        <OktaError error={error}/>
+      );
+      expect(wrapper.text()).toBe(`Error: ${errorMessage}`);
+    });
+    it('renders an AuthSdkError', () => {
+      const errorMessage = 'I am a test error message';
+      const error = new AuthSdkError(errorMessage);
+      const wrapper = mount(
+        <OktaError error={error}/>
+      );
+      expect(wrapper.text()).toBe(`AuthSdkError: ${errorMessage}`);
+    });
+    it('renders an AuthApiError', () => {
+      const errorSummary = 'I am a test error message';
+      const error = new AuthApiError({ errorSummary });
+      const wrapper = mount(
+        <OktaError error={error}/>
+      );
+      expect(wrapper.text()).toBe(`AuthApiError: ${errorSummary}`);
+    });
+    it('renders an OAuthError', () => {
+      const errorCode = 400;
+      const errorSummary = 'I am a test error message';
+      const error = new OAuthError(errorCode, errorSummary);
+      const wrapper = mount(
+        <OktaError error={error}/>
+      );
+      expect(wrapper.text()).toBe(`OAuthError: ${errorSummary}`);
+    });
+});
+


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?

Currently a pending async initial authState determination can replace any error message shown in LoginCallback from trying to handle authentication of the tokens in the URL.

Issue Number: #719


## What is the new behavior?

Now LoginCallback will wait until the initial authState determination is complete before triggering the handleAuthentication or showing any error.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

