### PR TITLE
feat[react-native]: add android custom signin support - OKTA-289380

### DIFF
--- a/packages/okta-react-native/.watchmanconfig
+++ b/packages/okta-react-native/.watchmanconfig
@@ -1,0 +1,5 @@
+{
+  "ignore_dirs": [
+    "node_modules"
+  ]
+}

--- a/packages/okta-react-native/OktaSdkBridgeReactNative.podspec
+++ b/packages/okta-react-native/OktaSdkBridgeReactNative.podspec
@@ -19,6 +19,7 @@ Pod::Spec.new do |s|
   s.source_files  = 'ios/**/*.{h,m,swift}',  'packages/okta-react-native/ios/**/*.{h,m,swift}'
 
   s.dependency 'React'
-  s.dependency "OktaOidc"
+  s.dependency 'OktaOidc'
+  s.dependency 'OktaAuthSdk', '>2'
 end
 

--- a/packages/okta-react-native/README.md
+++ b/packages/okta-react-native/README.md
@@ -193,7 +193,10 @@ await createConfig({
 
 ### `signIn`
 
-This async method will automatically redirect users to your Okta organziation for authentication. It will emit an event once a user successfully signs in. Make sure your event listeners are mounted and unmounted. Note: on iOS there isn't a `onCancelled` event. If the sign in process is cancelled, `onError` will be triggered. 
+This method will handle both `browser-sign-in` and `custom-sign-in` scenarios based on provided arguments.
+
+#### `browser-sign-in`
+`browser-sign-in` leverages device's native browser to automatically redirect users to your Okta organziation for authentication. By providing no argument, this method will trigger the `browser-sign-in` flow. It will emit an event once a user successfully signs in. Make sure your event listeners are mounted and unmounted. **Note**: on iOS there isn't a `onCancelled` event. If the sign in process is cancelled, `onError` will be triggered. 
 
 ```javascript
 signIn();
@@ -228,6 +231,21 @@ componentWillUnmount() {
 }
 
 ``` 
+
+#### `custom-sign-in`
+`custom-sign-in` provides the way to authenticate the user within the native application. By providing `cred` object with username and password fields, this method will retrieve `sessionToken` then exchange it for `accessToken`. Promise will be returned to handle success result and failures. Meanwhile, events will also be emitted as described in `browser-sign-in`.
+
+##### Sample Usage
+```javascript
+signIn({ username: "{username}", password: "{password}" })
+  .then(token => {
+    // consume accessToken from token.access_token
+  })
+  .catch(error => {
+    // handle error
+  })
+```
+
 
 ### `authenticate`
 

--- a/packages/okta-react-native/android/build.gradle
+++ b/packages/okta-react-native/android/build.gradle
@@ -70,6 +70,10 @@ repositories {
 dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation 'com.okta.android:oidc-androidx:1.0.8'
+    implementation 'com.okta.authn.sdk:okta-authn-sdk-api:1.0.0'
+    runtimeOnly 'com.okta.authn.sdk:okta-authn-sdk-impl:1.0.0'
+    runtimeOnly 'com.okta.sdk:okta-sdk-okhttp:1.5.2'
+    runtimeOnly 'com.squareup.okhttp3:okhttp:3.14.1'
 }
 
 def configureReactNativePom(def pom) {

--- a/packages/okta-react-native/android/src/main/java/com/oktareactnative/OktaSdkBridgeModule.java
+++ b/packages/okta-react-native/android/src/main/java/com/oktareactnative/OktaSdkBridgeModule.java
@@ -49,6 +49,9 @@ import com.okta.oidc.net.response.UserInfo;
 import com.okta.oidc.storage.SharedPreferenceStorage;
 import com.okta.oidc.util.AuthorizationException;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+
 public class OktaSdkBridgeModule extends ReactContextBaseJavaModule implements ActivityEventListener{
 
     private final ReactApplicationContext reactContext;
@@ -107,8 +110,9 @@ public class OktaSdkBridgeModule extends ReactContextBaseJavaModule implements A
                     .setRequireHardwareBackedKeyStore(requireHardwareBackedKeyStore)
                     .create();
 
+            String authnUrl = getAuthnUrl(discoveryUri);
             this.authnClient = AuthenticationClients.builder()
-                .setOrgUrl(discoveryUri)
+                .setOrgUrl(authnUrl)
                 .build();
 
             promise.resolve(true);
@@ -593,5 +597,10 @@ public class OktaSdkBridgeModule extends ReactContextBaseJavaModule implements A
         } catch (AuthorizationException e) {
             promise.reject(OktaSdkError.OKTA_OIDC_ERROR.getErrorCode(), e.getLocalizedMessage(), e);
         }
+    }
+
+    private String getAuthnUrl(String urlStr) throws MalformedURLException {
+        URL url = new URL(urlStr);
+        return url.getProtocol() + "://" + url.getHost();
     }
 }

--- a/packages/okta-react-native/index.js
+++ b/packages/okta-react-native/index.js
@@ -90,7 +90,18 @@ export const getIdToken = async() => {
 }
 
 export const getUser = async() => {
-  return NativeModules.OktaSdkBridge.getUser();
+  return NativeModules.OktaSdkBridge.getUser()
+    .then(data => {
+      if (typeof data === 'string') {
+        try {
+          return JSON.parse(data);
+        } catch (e) {
+          throw { code: 500, message: 'Invalid response' };
+        }
+      }
+
+      return data;
+    });
 }
 
 export const getUserFromIdToken = async() => {

--- a/packages/okta-react-native/index.js
+++ b/packages/okta-react-native/index.js
@@ -49,7 +49,27 @@ export const createConfig = async({
   );
 } 
 
-export const signIn = async() => {
+/**
+ * SignIn function to handle both "browser signIn" and "custom signIn" scenarios.
+ * 
+ * @param   {Object} [cred] Credential object provides username and password.
+ * @param   {string} [cred.username]
+ * @param   {string} [cred.password]
+ * @return  {Promise} promise | undefined
+ * @throws  Will throw an error if empty cred object is provided.
+ */
+export const signIn = async (cred) => {
+  // Custom sign in
+  if (cred && typeof cred === 'object') {
+    const { username, password } = cred;
+    if (!username || !password) {
+      throw { code: 400, message: 'Invalid client inputs' };
+    }
+
+    return NativeModules.OktaSdkBridge.signIn(username, password);
+  }
+
+  // Browser sign in
   return NativeModules.OktaSdkBridge.signIn();
 }
 

--- a/packages/okta-react-native/index.test.js
+++ b/packages/okta-react-native/index.test.js
@@ -184,10 +184,20 @@ describe('OktaReactNative', () => {
     });
 
     it('gets id token successfully', async () => {
-      mockGetUser.mockReturnValueOnce({
+      mockGetUser.mockResolvedValue({
         'name': 'Joe Doe',
         'sub': '00uid4BxXw6I6TV4m0g3',
       });
+      expect.assertions(1);
+      const data = await getUser();
+      expect(data).toEqual({
+        'name': 'Joe Doe',
+        'sub': '00uid4BxXw6I6TV4m0g3',
+      });
+    });
+
+    it('gets id token successfully from json string result', async () => {
+      mockGetUser.mockResolvedValue("{\"name\":\"Joe Doe\",\"sub\":\"00uid4BxXw6I6TV4m0g3\"}");
       expect.assertions(1);
       const data = await getUser();
       expect(data).toEqual({

--- a/packages/okta-react-native/ios/OktaSDKError.swift
+++ b/packages/okta-react-native/ios/OktaSDKError.swift
@@ -22,6 +22,7 @@ public enum OktaReactNativeError: Error {
     case errorTokenType
     case errorPayload
     case noAccessToken
+    case signInFailed
 }
 
 extension OktaReactNativeError: LocalizedError {
@@ -45,6 +46,8 @@ extension OktaReactNativeError: LocalizedError {
             return NSLocalizedString("Error in retrieving payload", comment: "")
         case .noAccessToken:
             return NSLocalizedString("No access token found", comment: "")
+        case .signInFailed:
+            return NSLocalizedString("Sign in was not authorized", comment: "")
         }
     }
     public var errorCode: String? {
@@ -67,6 +70,8 @@ extension OktaReactNativeError: LocalizedError {
             return "-800"
         case .noAccessToken:
             return "-900"
+        case .signInFailed:
+            return "-1000"
         }
     }
 }

--- a/packages/okta-react-native/ios/ReactNativeOktaSdkBridge.m
+++ b/packages/okta-react-native/ios/ReactNativeOktaSdkBridge.m
@@ -18,6 +18,14 @@ RCT_EXTERN_METHOD(createConfig:(NSString *)clientId redirectUrl:(NSString *)redi
 
 RCT_EXTERN_METHOD(signIn)
 
+RCT_EXTERN_METHOD(
+  signIn:
+  (NSString *)username 
+  password:(NSString *) password 
+  promiseResolver:(RCTPromiseResolveBlock *)promiseResolver 
+  promiseRejecter:(RCTPromiseRejectBlock *)promiseRejecter
+)
+
 RCT_EXTERN_METHOD(authenticate:(NSString *)sessionToken)
 
 RCT_EXTERN_METHOD(signOut)


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currenly there is no support in sdk for custom-sigin-in.


## What is the new behavior?
Add custom sign in support for both ios and android. 

**Implementation detail:**
Add one more signIn overloading method in both ios and android bridge code to get the sessionToken from authN client first, then exchange accessToken with sessionToken. 
Promise is returned in newly added signIn method.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

