### PR TITLE
Fixes autoRenew to pass through explicitly false settings

### DIFF
--- a/packages/configuration-validation/CHANGELOG.md
+++ b/packages/configuration-validation/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.4.2
+
+### Bug Fixes
+
+- `autoRenew: false` at the top of a config (not in tokenManager) now actually passies into tokenManager.  The previous behavior caused problems with libraries (such as @okta/okta-auth-js) that tried to assign defaults of `true` to any params not explicitly set, as they would not see any explictly `false` setting.  
+
 # 0.4.1
 
 ### Bug Fixes

--- a/packages/configuration-validation/CHANGELOG.md
+++ b/packages/configuration-validation/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug Fixes
 
-- `autoRenew: false` at the top of a config (not in tokenManager) now actually passies into tokenManager.  The previous behavior caused problems with libraries (such as @okta/okta-auth-js) that tried to assign defaults of `true` to any params not explicitly set, as they would not see any explictly `false` setting.  
+- [#754] `autoRenew: false` at the top of a config (not in tokenManager) now actually passies into tokenManager.  The previous behavior caused problems with libraries (such as @okta/okta-auth-js) that tried to assign defaults of `true` to any params not explicitly set, as they would not see any explictly `false` setting.  
 
 # 0.4.1
 

--- a/packages/configuration-validation/CHANGELOG.md
+++ b/packages/configuration-validation/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug Fixes
 
-- [#754] `autoRenew: false` at the top of a config (not in tokenManager) now actually passies into tokenManager.  The previous behavior caused problems with libraries (such as @okta/okta-auth-js) that tried to assign defaults of `true` to any params not explicitly set, as they would not see any explictly `false` setting.  
+- [#754] `autoRenew: false` at the top of a config (not in tokenManager) now actually passes into tokenManager.  The previous behavior caused problems with libraries (such as @okta/okta-auth-js) that tried to assign defaults of `true` to any params not explicitly set, as they would not see any explictly `false` setting.  
 
 # 0.4.1
 

--- a/packages/configuration-validation/package.json
+++ b/packages/configuration-validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okta/configuration-validation",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Configuration validation support for Okta JavaScript SDKs",
   "main": "./dist/lib.js",
   "files": [

--- a/packages/configuration-validation/src/lib.js
+++ b/packages/configuration-validation/src/lib.js
@@ -47,9 +47,9 @@ configUtil.buildConfigObject = (config) => {
 
   // Legacy support: allow TokenManager config 'autoRenew' and 'storage' to be defined at top-level
   let tokenManager = config.tokenManager;
-  const autoRenew = config.autoRenew || config.auto_renew;
+  const autoRenew = ( config.autoRenew !== undefined ? config.autoRenew : config.auto_renew); // Only check legacy property if necessary
   const storage = config.storage;
-  if (storage || autoRenew) {
+  if (storage !== undefined || autoRenew !== undefined ) {
     // Properties already defined within the "tokenManager" section will not be overwritten
     tokenManager = merge({
       autoRenew: autoRenew,

--- a/packages/configuration-validation/test/lib.test.js
+++ b/packages/configuration-validation/test/lib.test.js
@@ -43,6 +43,20 @@ describe('Configuration Validation', () => {
       expect(buildConfigObject(passedConfig)).toEqual(passedConfig);
     });
 
+    it('does not allow "autoRenew: false" to be overridden by undefined "auto_renew"', () => { 
+      const passedConfig = {
+        autoRenew: false,
+      };
+
+      expect(buildConfigObject(passedConfig)).toEqual({
+        autoRenew: false,
+        tokenManager: { 
+          autoRenew: false
+        },
+      });
+    });
+
+
     it('pass-through: Allows passing extra config properties at top-level', () => {
       function f() {}
       const passedConfig = {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #596 


## What is the new behavior?

An explicitly set top-level `autoRenew: false` will actually pass through.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

