### PR TITLE
Pass authService context if custom isAuthenticated method is passed

### DIFF
--- a/packages/okta-react/src/AuthService.js
+++ b/packages/okta-react/src/AuthService.js
@@ -139,7 +139,7 @@ class AuthService {
       const idToken = await this.getIdToken();
 
       // Use external check, or default to isAuthenticated if either the access or id token exist
-      const isAuthenticated = this._config.isAuthenticated ? await this._config.isAuthenticated() : !! ( accessToken || idToken );
+      const isAuthenticated = this._config.isAuthenticated ? await this._config.isAuthenticated(this) : !! ( accessToken || idToken );
 
       this._pending.authStateUpdate = null;
       this.emitAuthState({ 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?

I want to pass a custom `isAuthenticated` method to the `Security` component, but I can't because I don't have access to the context, specifically, the `getAccessToken`, and `getIdToken` methods.

## What is the new behavior?

A custom `isAuthenticated` method has access to the authService context

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
