### PR TITLE
fix[okta-react]: Fixes SecureRoute rendering

### DIFF
--- a/packages/okta-react/src/SecureRoute.js
+++ b/packages/okta-react/src/SecureRoute.js
@@ -14,7 +14,7 @@ import React from 'react';
 import { Route, useHistory } from 'react-router-dom';
 import { useOktaAuth } from './OktaContext';
 
-const SecureRoute = ({ ...props }) => {
+const SecureRoute = (props) => {
   const { authService, authState } = useOktaAuth();
   const history = useHistory();
 

--- a/packages/okta-react/src/SecureRoute.js
+++ b/packages/okta-react/src/SecureRoute.js
@@ -11,39 +11,22 @@
  */
 
 import React from 'react';
+import { Route, useHistory } from 'react-router-dom';
 import { useOktaAuth } from './OktaContext';
-import { useHistory, Route } from 'react-router-dom';
 
-const RequireAuth = ({ children }) => { 
+const SecureRoute = ({ ...props }) => {
   const { authService, authState } = useOktaAuth();
   const history = useHistory();
 
-  if(!authState.isAuthenticated) { 
-    if(!authState.isPending) { 
+  if (!authState.isAuthenticated) {
+    if (!authState.isPending) {
       const fromUri = history.createHref(history.location);
       authService.login(fromUri);
     }
     return null;
   }
 
-  return (
-    <React.Fragment>
-      {children}
-    </React.Fragment>
-  );
-
-};
-
-const SecureRoute = ( {component, ...props} ) => { 
-
-  const PassedComponent = component || function() { return null; };
-  const WrappedComponent = (wrappedProps) => (<RequireAuth><PassedComponent {...wrappedProps}/></RequireAuth>);
-  return (
-    <Route
-      { ...props }
-      render={ (routeProps) => props.render ? props.render({...routeProps, component: WrappedComponent}) : <WrappedComponent {...routeProps}/> } 
-    />
-  );
+  return <Route {...props} />;
 };
 
 export default SecureRoute;

--- a/packages/okta-react/test/jest/secureRoute.test.js
+++ b/packages/okta-react/test/jest/secureRoute.test.js
@@ -1,5 +1,5 @@
-import React from 'react';
 import { mount } from 'enzyme';
+import React from 'react';
 import { MemoryRouter, Route } from 'react-router-dom';
 import SecureRoute from '../../src/SecureRoute';
 import Security from '../../src/Security';
@@ -41,6 +41,131 @@ describe('<SecureRoute />', () => {
       );
       expect(wrapper.find(MyComponent).html()).toBe('<div>hello world</div>');
     });
+    it('will render wrapped component using render function', () => {
+      const MyComponent = function() { return <div>hello world</div>; };
+      const wrapper = mount(
+        <MemoryRouter>
+          <Security {...mockProps}>
+            <SecureRoute
+              render={() => <MyComponent />}
+            />
+          </Security>
+        </MemoryRouter>
+      );
+      expect(wrapper.find(MyComponent).html()).toBe('<div>hello world</div>');
+    });
+    it('should accept a "path" prop and render a component', () => {
+      const wrapper = mount(
+        <MemoryRouter>
+          <Security {...mockProps}>
+            <SecureRoute
+              path='/'
+            />
+          </Security>
+        </MemoryRouter>
+      );
+      expect(wrapper.find(SecureRoute).props().path).toBe('/');
+    });
+  
+    it('should accept an "exact" prop and render a component', () => {
+      const wrapper = mount(
+        <MemoryRouter>
+          <Security {...mockProps}>
+            <SecureRoute
+              exact={true}
+              path='/'
+            />
+          </Security>
+        </MemoryRouter>
+      );
+      expect(wrapper.find(SecureRoute).props().exact).toBe(true);
+    });
+  
+    it('should not contain an "exact" prop and render a component', () => {
+      const wrapper = mount(
+        <MemoryRouter>
+          <Security {...mockProps}>
+            <SecureRoute
+              path='/'
+            />
+          </Security>
+        </MemoryRouter>
+      );
+      expect(wrapper.find(SecureRoute).props().exact).toBeUndefined();
+    });
+  
+    it('should accept a "strict" prop and render a component', () => {
+      const wrapper = mount(
+        <MemoryRouter>
+          <Security {...mockProps}>
+            <SecureRoute
+              strict={true}
+              path='/'
+            />
+          </Security>
+        </MemoryRouter>
+      );
+      expect(wrapper.find(SecureRoute).props().strict).toBe(true);
+    });
+  
+    it('should accept a "sensitive" prop and render a component', () => {
+      const wrapper = mount(
+        <MemoryRouter>
+          <Security {...mockProps}>
+            <SecureRoute
+              sensitive={true}
+              path='/'
+            />
+          </Security>
+        </MemoryRouter>
+      );
+      expect(wrapper.find(SecureRoute).props().sensitive).toBe(true);
+    });
+  
+    it('should accept an "exact" prop and pass it to an internal Route', () => {
+      const wrapper = mount(
+        <MemoryRouter>
+          <Security {...mockProps}>
+            <SecureRoute
+              exact={true}
+              path='/'
+            />
+          </Security>
+        </MemoryRouter>
+      );
+      const secureRoute = wrapper.find(SecureRoute);
+      expect(secureRoute.find(Route).props().exact).toBe(true);
+    });
+  
+    it('should accept a "strict" prop and pass it to an internal Route', () => {
+      const wrapper = mount(
+        <MemoryRouter>
+          <Security {...mockProps}>
+            <SecureRoute
+              strict={true}
+              path='/'
+            />
+          </Security>
+        </MemoryRouter>
+      );
+      const secureRoute = wrapper.find(SecureRoute);
+      expect(secureRoute.find(Route).props().strict).toBe(true);
+    });
+  
+    it('should accept a "sensitive" prop and pass it to an internal Route', () => {
+      const wrapper = mount(
+        <MemoryRouter>
+          <Security {...mockProps}>
+            <SecureRoute
+              sensitive={true}
+              path='/'
+            />
+          </Security>
+        </MemoryRouter>
+      );
+      const secureRoute = wrapper.find(SecureRoute);
+      expect(secureRoute.find(Route).props().sensitive).toBe(true);
+    });
   });
 
   describe('isAuthenticated: false', () => {
@@ -62,7 +187,19 @@ describe('<SecureRoute />', () => {
       );
       expect(wrapper.find(MyComponent).length).toBe(0);
     });
-
+    it('will not render wrapped component when using render function', () => {
+      const MyComponent = function() { return <div>hello world</div>; };
+      const wrapper = mount(
+        <MemoryRouter>
+          <Security {...mockProps}>
+            <SecureRoute
+              render={() => <MyComponent />}
+            />
+          </Security>
+        </MemoryRouter>
+      );
+      expect(wrapper.find(MyComponent).length).toBe(0);
+    });
     describe('isPending: false', () => {
 
       beforeEach(() => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
SecureRoute renders render prop without authentication

Issue Number: #743 

SecureRoute doesn't pass router props through

Issue Number: #724 


## What is the new behavior?
SecureRoute authenticates before rendering any routes.
SecureRoute passes through all props 

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
Unit tests have been rearranged to reflect that Routes are now only rendered when user is authenticated

## Reviewers

