### PR TITLE
fix[configuration-validation]: updates lodash to runtime dependency

### DIFF
--- a/packages/configuration-validation/package.json
+++ b/packages/configuration-validation/package.json
@@ -37,10 +37,12 @@
     "babel-preset-env": "^1.7.0",
     "deep-extend": "^0.6.0",
     "eslint": "^4.7.1",
-    "jest": "^23.6.0",
-    "lodash": "^4.17.15"
+    "jest": "^23.6.0"
   },
   "jest": {
     "testEnvironment": "jsdom"
+  },
+  "dependencies": {
+    "lodash": "^4.17.15"
   }
 }


### PR DESCRIPTION
`lodash` is currently listed as a devDependency, it should instead be listed as a runtime dependency. 
Resolves: #779

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [X] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #779


## What is the new behavior?

`lodash` should be listed as a runtime dependency as its used directly on the logic for this package.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

