### PR TITLE
feat[okta-react-native]: pass supported browsers to config

### DIFF
--- a/packages/okta-react-native/README.md
+++ b/packages/okta-react-native/README.md
@@ -192,6 +192,7 @@ await createConfig({
   endSessionRedirectUri: "{endSessionRedirectUri}",
   discoveryUri: "https://{yourOktaDomain}",
   scopes: ["openid", "profile", "offline_access"],
+  supportedBrowsers: ["org.mozilla.firefox", "com.sec.android.app.sbrowser"], // available for Android only
   requireHardwareBackedKeyStore: true
 });
 ``` 

--- a/packages/okta-react-native/android/src/main/java/com/oktareactnative/OktaSdkBridgeModule.java
+++ b/packages/okta-react-native/android/src/main/java/com/oktareactnative/OktaSdkBridgeModule.java
@@ -69,21 +69,16 @@ public class OktaSdkBridgeModule extends ReactContextBaseJavaModule implements A
                              String discoveryUri,
                              ReadableArray scopes,
                              Boolean requireHardwareBackedKeyStore,
+                             ReadableArray supportedBrowsers,
                              Promise promise
     ) {
 
         try {
-            String[] scopeArray = new String[scopes.size()];
-
-            for (int i = 0; i < scopes.size(); i++) {
-                scopeArray[i] = scopes.getString(i);
-            }
-
             this.config = new OIDCConfig.Builder()
                     .clientId(clientId)
                     .redirectUri(redirectUri)
                     .endSessionRedirectUri(endSessionRedirectUri)
-                    .scopes(scopeArray)
+                    .scopes(this.mapReadableArrayToArray(scopes))
                     .discoveryUri(discoveryUri)
                     .create();
 
@@ -92,6 +87,7 @@ public class OktaSdkBridgeModule extends ReactContextBaseJavaModule implements A
                     .withContext(reactContext)
                     .withStorage(new SharedPreferenceStorage(reactContext))
                     .setRequireHardwareBackedKeyStore(requireHardwareBackedKeyStore)
+                    .supportedBrowsers(this.mapReadableArrayToArray(supportedBrowsers))
                     .create();
 
             this.authClient = new Okta.AuthBuilder()
@@ -538,5 +534,19 @@ public class OktaSdkBridgeModule extends ReactContextBaseJavaModule implements A
         } catch (AuthorizationException e) {
             promise.reject(OktaSdkError.OKTA_OIDC_ERROR.getErrorCode(), e.getLocalizedMessage(), e);
         }
+    }
+
+    private String[] mapReadableArrayToArray(ReadableArray readableArray) {
+        if (readableArray == null) {
+            return new String[0];
+        }
+
+        int size = readableArray.size();
+        String[] array = new String[size];
+
+        for (int i = 0; i < size; i++) {
+            array[i] = readableArray.getString(i);
+        }
+        return array;
     }
 }

--- a/packages/okta-react-native/index.js
+++ b/packages/okta-react-native/index.js
@@ -35,7 +35,8 @@ export const createConfig = async({
   endSessionRedirectUri, 
   discoveryUri,
   scopes,
-  requireHardwareBackedKeyStore
+  requireHardwareBackedKeyStore,
+  supportedBrowsers
 }) => {
 
   assertIssuer(discoveryUri);
@@ -68,7 +69,8 @@ export const createConfig = async({
     endSessionRedirectUri,
     discoveryUri,
     scopes,
-    requireHardwareBackedKeyStore
+    requireHardwareBackedKeyStore,
+    supportedBrowsers
   );
 } 
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?

If Chrome is not selected as the default browser on the mobile, the signIn function returns a -600 error and the OKTA login page never shows up. Once Chrome is selected as default browser, it all works fine.

This PR adds the possibility to pass the browsers we want to support like Firefox and Samsung. 

## What is the new behavior?

If FF or Samsung are the browser selected as default, the OKTA login page shows up (if we pass them as supported browser to the config)

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

ENGIE is a big fan of OKTA and we are using this library to integrate with OKTA. We notice that the sign in functionality was not working for users whose FF or Samsung were selected as default users. For our use, we need to be able to pass have the OKTA login page work for other brower than just chrome.

## Reviewers

