### PR TITLE
fix[react-native]: pass consistent UA - OKTA-296091

### DIFF
--- a/packages/okta-react-native/CHANGELOG.md
+++ b/packages/okta-react-native/CHANGELOG.md
@@ -1,4 +1,10 @@
-#1.4.0
+# 1.4.1
+
+### Bug fix
+
+- [#790](https://github.com/okta/okta-oidc-js/pull/790) Pass consistent UA header in http request
+
+# 1.4.0
 
 ### Features
 - [#751](https://github.com/okta/okta-oidc-js/pull/751)

--- a/packages/okta-react-native/android/build.gradle
+++ b/packages/okta-react-native/android/build.gradle
@@ -69,7 +69,7 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.okta.android:oidc-androidx:1.0.8'
+    implementation 'com.okta.android:oidc-androidx:1.0.13'
 }
 
 def configureReactNativePom(def pom) {

--- a/packages/okta-react-native/android/src/main/java/com/oktareactnative/HttpClientImpl.java
+++ b/packages/okta-react-native/android/src/main/java/com/oktareactnative/HttpClientImpl.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2019, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package com.oktareactnative;
+
+import android.annotation.SuppressLint;
+import android.net.Uri;
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
+
+import com.okta.oidc.BuildConfig;
+import com.okta.oidc.net.ConnectionParameters;
+import com.okta.oidc.net.OktaHttpClient;
+import com.okta.oidc.net.request.TLSSocketFactory;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+import java.util.Map;
+
+import javax.net.ssl.HttpsURLConnection;
+
+import static com.okta.oidc.net.ConnectionParameters.USER_AGENT;
+
+public class HttpClientImpl implements OktaHttpClient {
+    private HttpURLConnection mUrlConnection;
+    private String userAgentTemplate;
+
+    HttpClientImpl(String userAgentTemplate) {
+        this.userAgentTemplate = userAgentTemplate;
+    }
+
+    /*
+     * TLS v1.1, v1.2 in Android supports starting from API 16.
+     * But it enabled by default starting from API 20.
+     * This method enable these TLS versions on API < 20.
+     * */
+    @SuppressLint("RestrictedApi")
+    private void enableTlsV1_2(HttpURLConnection urlConnection) {
+        try {
+            ((HttpsURLConnection) urlConnection)
+                    .setSSLSocketFactory(new TLSSocketFactory());
+        } catch (NoSuchAlgorithmException | KeyManagementException e) {
+            throw new RuntimeException("Cannot create SSLContext.", e);
+        }
+    }
+
+    private String getUserAgent() {
+        String sdkVersion = BuildConfig.APPLICATION_ID + "/" + BuildConfig.VERSION_NAME;
+        return userAgentTemplate.replace("$UPSTREAM_SDK", sdkVersion);
+    }
+
+    protected HttpURLConnection openConnection(URL url, ConnectionParameters params)
+            throws IOException {
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        if (mUrlConnection instanceof HttpsURLConnection &&
+                Build.VERSION.SDK_INT <= Build.VERSION_CODES.LOLLIPOP) {
+            enableTlsV1_2(mUrlConnection);
+        }
+
+        conn.setConnectTimeout(params.connectionTimeoutMs());
+        conn.setReadTimeout(params.readTimeOutMs());
+        conn.setInstanceFollowRedirects(false);
+
+        Map<String, String> requestProperties = params.requestProperties();
+        String userAgent = getUserAgent();
+        requestProperties.put(USER_AGENT, userAgent);
+        if (requestProperties != null) {
+            for (String property : requestProperties.keySet()) {
+                conn.setRequestProperty(property, requestProperties.get(property));
+            }
+        }
+
+        ConnectionParameters.RequestMethod requestMethod = params.requestMethod();
+        Map<String, String> postParameters = params.postParameters();
+        conn.setRequestMethod(requestMethod.name());
+        if (requestMethod == ConnectionParameters.RequestMethod.GET) {
+            conn.setDoInput(true);
+        } else if (requestMethod == ConnectionParameters.RequestMethod.POST) {
+            conn.setDoOutput(true);
+            if (postParameters != null && !postParameters.isEmpty()) {
+                DataOutputStream out = new DataOutputStream(conn.getOutputStream());
+                out.write(params.getEncodedPostParameters());
+                out.close();
+            }
+        }
+        return conn;
+    }
+
+    @Override
+    public InputStream connect(@NonNull Uri uri, @NonNull ConnectionParameters params)
+            throws Exception {
+
+        mUrlConnection = openConnection(new URL(uri.toString()), params);
+        mUrlConnection.connect();
+        try {
+            return mUrlConnection.getInputStream();
+        } catch (IOException e) {
+            return mUrlConnection.getErrorStream();
+        }
+    }
+
+
+    @Override
+    public void cleanUp() {
+        mUrlConnection = null;
+    }
+
+    @Override
+    public void cancel() {
+        if (mUrlConnection != null) {
+            mUrlConnection.disconnect();
+        }
+    }
+
+    @Override
+    public Map<String, List<String>> getHeaderFields() {
+        if (mUrlConnection != null) {
+            return mUrlConnection.getHeaderFields();
+        }
+        return null;
+    }
+
+    @Override
+    public String getHeader(String header) {
+        if (mUrlConnection != null) {
+            return mUrlConnection.getHeaderField(header);
+        }
+        return null;
+    }
+
+    @Override
+    public int getResponseCode() throws IOException {
+        if (mUrlConnection != null) {
+            return mUrlConnection.getResponseCode();
+        }
+        return -1;
+    }
+
+    @Override
+    public int getContentLength() {
+        if (mUrlConnection != null) {
+            return mUrlConnection.getContentLength();
+        }
+        return -1;
+    }
+
+    @Override
+    public String getResponseMessage() throws IOException {
+        if (mUrlConnection != null) {
+            return mUrlConnection.getResponseMessage();
+        }
+        return null;
+    }
+
+    public HttpURLConnection getUrlConnection() {
+        return mUrlConnection;
+    }
+}

--- a/packages/okta-react-native/android/src/main/java/com/oktareactnative/HttpClientImpl.java
+++ b/packages/okta-react-native/android/src/main/java/com/oktareactnative/HttpClientImpl.java
@@ -62,7 +62,7 @@ public class HttpClientImpl implements OktaHttpClient {
     }
 
     private String getUserAgent() {
-        String sdkVersion = BuildConfig.APPLICATION_ID + "/" + BuildConfig.VERSION_NAME;
+        String sdkVersion = "okta-oidc-android/" + BuildConfig.VERSION_NAME;
         return userAgentTemplate.replace("$UPSTREAM_SDK", sdkVersion);
     }
 

--- a/packages/okta-react-native/android/src/main/java/com/oktareactnative/OktaSdkBridgeModule.java
+++ b/packages/okta-react-native/android/src/main/java/com/oktareactnative/OktaSdkBridgeModule.java
@@ -68,6 +68,7 @@ public class OktaSdkBridgeModule extends ReactContextBaseJavaModule implements A
                              String endSessionRedirectUri,
                              String discoveryUri,
                              ReadableArray scopes,
+                             String userAgentTemplate,
                              Boolean requireHardwareBackedKeyStore,
                              Promise promise
     ) {
@@ -91,6 +92,7 @@ public class OktaSdkBridgeModule extends ReactContextBaseJavaModule implements A
                     .withConfig(config)
                     .withContext(reactContext)
                     .withStorage(new SharedPreferenceStorage(reactContext))
+                    .withOktaHttpClient(new HttpClientImpl(userAgentTemplate))
                     .setRequireHardwareBackedKeyStore(requireHardwareBackedKeyStore)
                     .create();
 
@@ -98,6 +100,7 @@ public class OktaSdkBridgeModule extends ReactContextBaseJavaModule implements A
                     .withConfig(config)
                     .withContext(reactContext)
                     .withStorage(new SharedPreferenceStorage(reactContext))
+                    .withOktaHttpClient(new HttpClientImpl(userAgentTemplate))
                     .setRequireHardwareBackedKeyStore(requireHardwareBackedKeyStore)
                     .create();
 

--- a/packages/okta-react-native/index.js
+++ b/packages/okta-react-native/index.js
@@ -43,11 +43,12 @@ export const createConfig = async({
   assertRedirectUri(redirectUri);
   assertRedirectUri(endSessionRedirectUri);
 
+  const userAgentTemplate = `@okta/okta-react-native/${version} $UPSTREAM_SDK react-native/${version} ${Platform.OS}/${Platform.Version}`;
   const { origin } = Url(discoveryUri);
   authClient = new OktaAuth({ 
     issuer: issuer || origin,
     userAgent: {
-      template: `@okta/okta-react-native/${version} $OKTA_AUTH_JS react-native/${version} ${Platform.OS}/${Platform.Version}`
+      template: userAgentTemplate.replace('$UPSTREAM_SDK', '$OKTA_AUTH_JS')
     } 
   });
 
@@ -68,6 +69,7 @@ export const createConfig = async({
     endSessionRedirectUri,
     discoveryUri,
     scopes,
+    userAgentTemplate,
     requireHardwareBackedKeyStore
   );
 } 

--- a/packages/okta-react-native/index.js
+++ b/packages/okta-react-native/index.js
@@ -59,7 +59,8 @@ export const createConfig = async({
       redirectUri,
       endSessionRedirectUri,
       discoveryUri,
-      scopes
+      scopes,
+      userAgentTemplate
     );
   }
     

--- a/packages/okta-react-native/index.test.js
+++ b/packages/okta-react-native/index.test.js
@@ -31,6 +31,7 @@ const {
 } = jest.requireActual('./');
 
 import { Platform } from 'react-native';
+import { version } from './package.json';
 
 jest.mock('react-native', () => {
   return ({
@@ -82,6 +83,7 @@ describe('OktaReactNative', () => {
     
     it('passes in correct parameters on ios device', () => {
       Platform.OS = 'ios';
+      Platform.Version = '1.0.0';
       const processedScope = config.scopes.join(' ');
       createConfig(config);
       expect(mockCreateConfig).toHaveBeenCalledWith(
@@ -90,11 +92,13 @@ describe('OktaReactNative', () => {
         config.endSessionRedirectUri,
         config.discoveryUri,
         processedScope,
+        `@okta/okta-react-native/${version} $UPSTREAM_SDK react-native/${version} ios/1.0.0`,
       );
     });
 
     it('passes in correct parameters on android device', () => {
       Platform.OS = 'android';
+      Platform.Version = '1.0.0';
       createConfig(config);
       expect(mockCreateConfig).toHaveBeenCalledWith(
         config.clientId,
@@ -102,6 +106,7 @@ describe('OktaReactNative', () => {
         config.endSessionRedirectUri,
         config.discoveryUri,
         config.scopes,
+        `@okta/okta-react-native/${version} $UPSTREAM_SDK react-native/${version} android/1.0.0`,
         config.requireHardwareBackedKeyStore,
       );
     });

--- a/packages/okta-react-native/ios/OktaSdkBridge.swift
+++ b/packages/okta-react-native/ios/OktaSdkBridge.swift
@@ -25,9 +25,13 @@ class OktaSdkBridge: RCTEventEmitter {
                       endSessionRedirectUri: String,
                       discoveryUri: String,
                       scopes: String,
+                      userAgentTemplate: String,
                       promiseResolver: RCTPromiseResolveBlock,
                       promiseRejecter: RCTPromiseRejectBlock) -> Void {
         do {
+            let uaVersion = OktaUserAgent.userAgentVersion()
+            let userAgent = userAgentTemplate.replacingOccurrences(of: "$UPSTREAM_SDK", with: "okta-oidc-ios/\(uaVersion)")
+            OktaOidcConfig.setUserAgent(value: userAgent)
             config = try OktaOidcConfig(with: [
                 "issuer": discoveryUri,
                 "clientId": clientId,

--- a/packages/okta-react-native/ios/ReactNativeOktaSdkBridge.m
+++ b/packages/okta-react-native/ios/ReactNativeOktaSdkBridge.m
@@ -14,7 +14,17 @@
 
 @interface RCT_EXTERN_MODULE(OktaSdkBridge, RCTEventEmitter)
 
-RCT_EXTERN_METHOD(createConfig:(NSString *)clientId redirectUrl:(NSString *)redirectUrl endSessionRedirectUri:(NSString *)endSessionRedirectUri discoveryUri:(NSString *)discoveryUri scopes:(NSString *)scopes promiseResolver:(RCTPromiseResolveBlock *)promiseResolver promiseRejecter:(RCTPromiseRejectBlock *)promiseRejecter)
+RCT_EXTERN_METHOD(
+  createConfig:
+  (NSString *)clientId 
+  redirectUrl:(NSString *)redirectUrl 
+  endSessionRedirectUri:(NSString *)endSessionRedirectUri 
+  discoveryUri:(NSString *)discoveryUri 
+  scopes:(NSString *)scopes 
+  userAgentTemplate:(NSString *)userAgentTemplate 
+  promiseResolver:(RCTPromiseResolveBlock *)promiseResolver 
+  promiseRejecter:(RCTPromiseRejectBlock *)promiseRejecter
+)
 
 RCT_EXTERN_METHOD(signIn)
 

--- a/packages/okta-react-native/package.json
+++ b/packages/okta-react-native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@okta/okta-react-native",
   "title": "React Native Okta Sdk Bridge",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Okta OIDC for React Native",
   "main": "index.js",
   "podname": "OktaSdkBridgeReactNative",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`okta-react-native` currently depends on different upstream sdks to make HTTP request, which end up with different UAs be sent out without `react-native` info. 

Issue Number: N/A
OKTA-296091

## What is the new behavior?
Use following pattern to set UA in headers
```
@okta/okta-react-native/${version} $UPSTREAM_SDK react-native/${version} ${Platform.OS}/${Platform.Version}
```

Android 
![Screen Shot 2020-05-27 at 3 51 39 PM](https://user-images.githubusercontent.com/4027992/83073107-e0038e00-a03d-11ea-9ff9-c1745cc68b9d.png)

ios
<img width="605" alt="Screen Shot 2020-05-27 at 5 13 35 PM" src="https://user-images.githubusercontent.com/4027992/83073134-ea258c80-a03d-11ea-8afa-92a591fe2613.png">


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

