### PR TITLE
fix[react]: staled token state

### DIFF
--- a/packages/okta-react/CHANGELOG.md
+++ b/packages/okta-react/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.0.3
+
+### Bug Fixes
+
+- [#826](https://github.com/okta/okta-oidc-js/pull/826) Fix staled `authState` in React context by listening on `expired` event from `authJs.tokenManager`, then update the `authState` in context properly.
+
 # 3.0.2
 
 ### Bug Fixes

--- a/packages/okta-react/CHANGELOG.md
+++ b/packages/okta-react/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug Fixes
 
-- [#826](https://github.com/okta/okta-oidc-js/pull/826) Fix staled `authState` in React context by listening on `expired` event from `authJs.tokenManager`, then update the `authState` in context properly.
+- [#826](https://github.com/okta/okta-oidc-js/pull/826) Fix stale `authState` in React context by listening on `expired` event from `authJs.tokenManager`, then update the `authState` in context properly.
 
 # 3.0.2
 

--- a/packages/okta-react/package.json
+++ b/packages/okta-react/package.json
@@ -12,7 +12,8 @@
     "start": "yarn --cwd test/e2e/harness start",
     "test": "yarn lint && yarn test:unit && yarn test:e2e",
     "test:e2e": "yarn --cwd test/e2e/harness test",
-    "test:unit": "jest"
+    "test:unit": "jest",
+    "dev": "babel src -wd dist"
   },
   "repository": {
     "type": "git",
@@ -68,6 +69,7 @@
     "react-router-dom": "^5.1.0",
     "rimraf": "^2.6.2",
     "styled-components": "^2.1.2",
+    "tiny-emitter": "^2.1.0",
     "webdriver-manager": "^12.1.4"
   },
   "resolutions": {

--- a/packages/okta-react/src/AuthService.js
+++ b/packages/okta-react/src/AuthService.js
@@ -120,7 +120,6 @@ class AuthService {
   }
 
   async updateAuthState() {
-    console.log('call update auth state');
     // avoid concurrent updates
     if( this._pending.authStateUpdate ) { 
       return this._pending.authStateUpdate.promise;

--- a/packages/okta-react/src/AuthService.js
+++ b/packages/okta-react/src/AuthService.js
@@ -41,7 +41,6 @@ class AuthService {
     this._oktaAuth = new OktaAuth(authConfig);
     this._oktaAuth.userAgent = `${packageInfo.name}/${packageInfo.version} ${this._oktaAuth.userAgent}`;
     this._config = authConfig; // use normalized config
-    this._listeners = {};
     this._pending = {}; // manage overlapping async calls 
 
     this.handleAuthentication = this.handleAuthentication.bind(this);
@@ -59,9 +58,11 @@ class AuthService {
     this.emit = this.emit.bind(this);
     this.on = this.on.bind(this);
 
-    this._subscriberCount = 0;
-
     this.clearAuthState();
+
+    // Remove expired token or renew token if autoRenew is true
+    // This process will keep authState synced with states in tokenManager
+    this.on('expired', this.updateAuthState);
   }
 
   getTokenManager() {
@@ -119,6 +120,7 @@ class AuthService {
   }
 
   async updateAuthState() {
+    console.log('call update auth state');
     // avoid concurrent updates
     if( this._pending.authStateUpdate ) { 
       return this._pending.authStateUpdate.promise;
@@ -256,17 +258,14 @@ class AuthService {
   }
 
   on( event, callback ) {
-    const subscriberId = this._subscriberCount++;
-    this._listeners[event] = this._listeners[event] || {};
-    this._listeners[event][subscriberId] = callback;
-    return () => { 
-      delete this._listeners[event][subscriberId];
-    }
+    this._oktaAuth.emitter.on(event, callback, this._oktaAuth.emitter);
+    return () => {
+      this._oktaAuth.emitter.off(event, callback);
+    };
   }
 
   emit(event, message ) { 
-    this._listeners[event] = this._listeners[event] || {};
-    Object.values(this._listeners[event]).forEach( listener => listener(message) );
+    this._oktaAuth.emitter.emit(event, message);
   }
   
 }

--- a/packages/okta-react/test/jest/authService.test.js
+++ b/packages/okta-react/test/jest/authService.test.js
@@ -1,11 +1,23 @@
 import AuthService from '../../src/AuthService';
 import AuthJS from '@okta/okta-auth-js'
+import Emitter from 'tiny-emitter';
 
 const pkg = require('../../package.json');
 
 jest.mock('@okta/okta-auth-js');
 
 describe('AuthService configuration', () => {
+  let mockAuthJsInstance;
+
+  beforeEach(() => {
+    mockAuthJsInstance = {
+      userAgent: 'okta-auth-js',
+      emitter: new Emitter()
+    };
+    AuthJS.mockImplementation(() => {
+      return mockAuthJsInstance
+    });
+  })
 
   it('should throw if no issuer is provided', () => {
     function createInstance () {
@@ -164,6 +176,7 @@ describe('AuthService', () => {
     };
     mockAuthJsInstance = {
       userAgent: 'okta-auth-js',
+      emitter: new Emitter(),
       tokenManager: {
           add: jest.fn(),
           get: jest.fn().mockImplementation(tokenName => {
@@ -174,7 +187,7 @@ describe('AuthService', () => {
             } else {
               throw new Error('Unknown token name: ' + tokenName);
             }
-          }),
+          })
       },
       token: {
         getWithRedirect: jest.fn(),
@@ -506,6 +519,13 @@ describe('AuthService', () => {
 
   describe('AuthState tracking', () => { 
 
+    it('should call updateAuthState method when expired event happen', () => {
+      jest.spyOn(AuthService.prototype, 'updateAuthState');
+      const authService = new AuthService(validConfig);
+      authService.emit('expired');
+      expect(AuthService.prototype.updateAuthState).toHaveBeenCalled();
+    });
+
     it('has an authState of pending initially', async () => { 
       const authService = new AuthService({
         issuer: 'https://foo/oauth2/default',
@@ -519,21 +539,6 @@ describe('AuthService', () => {
         idToken: null,
         accessToken: null,
       });
-    });
-
-    it('allows subscribing to an "authStateChange" event', async () => { 
-      const authService = new AuthService({
-        issuer: 'https://foo/oauth2/default',
-        clientId: 'foo',
-        redirectUri: 'https://foo/redirect',
-      });
-      const callback = jest.fn();
-
-      expect(Object.values(authService._listeners.authStateChange).length).toBe(0);
-      authService.on('authStateChange', callback);
-      expect(Object.values(authService._listeners.authStateChange).length).toBe(1);
-      authService.emit('authStateChange');
-      expect(callback).toHaveBeenCalled();
     });
 
     it('emits an "authStateChange" event when updateAuthState() is called', async () => { 

--- a/packages/okta-react/test/jest/authService.test.js
+++ b/packages/okta-react/test/jest/authService.test.js
@@ -526,7 +526,7 @@ describe('AuthService', () => {
       expect(AuthService.prototype.updateAuthState).toHaveBeenCalled();
     });
 
-    it('should trigger registred callback when "authStateChange" event triggered', () => {
+    it('should trigger registered callback when "authStateChange" event triggered', () => {
       expect.assertions(1);
       const mockState = 'mock state';
       const authService = new AuthService({

--- a/packages/okta-react/test/jest/authService.test.js
+++ b/packages/okta-react/test/jest/authService.test.js
@@ -526,6 +526,20 @@ describe('AuthService', () => {
       expect(AuthService.prototype.updateAuthState).toHaveBeenCalled();
     });
 
+    it('should trigger registred callback when "authStateChange" event triggered', () => {
+      expect.assertions(1);
+      const mockState = 'mock state';
+      const authService = new AuthService({
+        issuer: 'https://foo/oauth2/default',
+        clientId: 'foo',
+        redirectUri: 'https://foo/redirect',
+      });
+      authService.on('authStateChange', (state) => {
+        expect(state).toEqual(mockState);
+      });
+      authService.emit('authStateChange', mockState);
+    });
+
     it('has an authState of pending initially', async () => { 
       const authService = new AuthService({
         issuer: 'https://foo/oauth2/default',

--- a/packages/okta-react/yarn.lock
+++ b/packages/okta-react/yarn.lock
@@ -5076,6 +5076,11 @@ tiny-emitter@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-1.1.0.tgz#ab405a21ffed814a76c19739648093d70654fecb"
 
+tiny-emitter@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
+  integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
+
 tiny-invariant@^1.0.2:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.0.6.tgz#b3f9b38835e36a41c843a3b0907a5a7b3755de73"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, the `okta-react` SDK keeps staled authState after user login. 

Issue Number: N/A


## What is the new behavior?
Listen on `expired` event from `okta-auth-js`, then renew (if autoRenew turned on) and update authState accordingly.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

