### PR TITLE
Adds handling of render and children to SecureRoute

### DIFF
--- a/packages/okta-react/CHANGELOG.md
+++ b/packages/okta-react/CHANGELOG.md
@@ -1,4 +1,4 @@
-# PENDING
+# 3.0.5
 
 ### Bug Fixes
 

--- a/packages/okta-react/CHANGELOG.md
+++ b/packages/okta-react/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#872](https://github.com/okta/okta-oidc-js/pull/872) Adjusts `<SecureRoute>` so that it enforces authentication requirement for components passed via "render" or "children" in addition to "component"
   - NOTE: `<SecureRoute>`, like react-router `<Route>`, only wants ONE of the three ways of passing wrapped components per route
+  - This should also address cases where components loaded through SecureRoute were being unnecessarily unmounted/remounted
 
 # 3.0.4
 

--- a/packages/okta-react/CHANGELOG.md
+++ b/packages/okta-react/CHANGELOG.md
@@ -1,3 +1,9 @@
+# PENDING
+
+### Bug Fixes
+
+- Adjusts `<SecureRoute>` so that it enforces authenticationRequirement for components passed via "render" or "children" in addition to "component"
+
 # 3.0.4
 
 ### Bug Fixes

--- a/packages/okta-react/CHANGELOG.md
+++ b/packages/okta-react/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Bug Fixes
 
-- Adjusts `<SecureRoute>` so that it enforces authenticationRequirement for components passed via "render" or "children" in addition to "component"
+- [#872](https://github.com/okta/okta-oidc-js/pull/872) Adjusts `<SecureRoute>` so that it enforces authentication requirement for components passed via "render" or "children" in addition to "component"
+  - NOTE: `<SecureRoute>`, like react-router `<Route>`, only wants ONE of the three ways of passing wrapped components per route
 
 # 3.0.4
 

--- a/packages/okta-react/README.md
+++ b/packages/okta-react/README.md
@@ -466,6 +466,11 @@ class App extends Component {
   
 `SecureRoute` integrates with `react-router`.  Other routers will need their own methods to ensure authentication using the hooks/HOC props provided by this SDK.
 
+As with `Route` from `react-router-dom`, `<SecureRoute>` can take one of:
+- a `component` prop that is passed a component
+- a `render` prop that is passed a function that returns a component.  This function will be passed any additional props that react-router injects (such as `history` or `match`)
+- children components
+
 ### `LoginCallback`
 
 `LoginCallback` handles the callback after the redirect to and back from the Okta-hosted login page. By default, it parses the tokens from the uri, stores them, then redirects to `/`. If a `SecureRoute` caused the redirect, then the callback redirects to the secured route. For more advanced cases, this component can be copied to your own source tree and modified as needed.

--- a/packages/okta-react/src/SecureRoute.js
+++ b/packages/okta-react/src/SecureRoute.js
@@ -45,6 +45,7 @@ const SecureRoute = ( {component, render, children, ...props} ) => {
 
   if( component || !render ) { // React-router has component take precedence over render
     const PassedComponent = component || function() { return <React.Fragment>{children}</React.Fragment>; };
+    // eslint-disable-next-line react/display-name
     authRender = wrappedProps => <PassedComponent { ...wrappedProps} />;
   }
 

--- a/packages/okta-react/src/SecureRoute.js
+++ b/packages/okta-react/src/SecureRoute.js
@@ -12,47 +12,25 @@
 
 import React, { useEffect } from 'react';
 import { useOktaAuth } from './OktaContext';
-import { useHistory, Route } from 'react-router-dom';
+import { Route } from 'react-router-dom';
 
-const RequireAuth = ({ render, routeProps }) => { 
+const SecureRoute = ( props ) => { 
   const { authService, authState } = useOktaAuth();
-  const history = useHistory();
 
   useEffect(() => {
     // Start login if and only if app has decided it is not logged inn
     if(!authState.isAuthenticated && !authState.isPending) { 
-      const fromUri = history.createHref(history.location);
-      authService.login(fromUri);
+      authService.login();
     }  
-  }, [authState, authService, history]);
+  }, [authState.isPending, authState.isAuthenticated, authService]);
 
   if (!authState.isAuthenticated) {
     return null;
   }
 
   return (
-    <React.Fragment>
-      { render(routeProps) }
-    </React.Fragment>
-  );
-};
-
-const SecureRoute = ( {component, render, children, ...props} ) => { 
-  // react-router Route uses exactly one of: render, component, children
-  // We wrap whichever they use to require authentication and use the render method on Route
-
-  let authRender = render;
-
-  if( component || !render ) { // React-router has component take precedence over render
-    const PassedComponent = component || function() { return <React.Fragment>{children}</React.Fragment>; };
-    // eslint-disable-next-line react/display-name
-    authRender = wrappedProps => <PassedComponent { ...wrappedProps} />;
-  }
-
-  return (
     <Route
       { ...props }
-      render={ routeProps => <RequireAuth render={authRender} routeProps={routeProps}/> }
     />
   );
 };

--- a/packages/okta-react/test/jest/secureRoute.test.js
+++ b/packages/okta-react/test/jest/secureRoute.test.js
@@ -31,6 +31,7 @@ describe('<SecureRoute />', () => {
 
     beforeEach(() => {
       authState.isAuthenticated = true;
+      authState.isPending = false;
     });
 
     it('will render wrapped component using "component"', () => {
@@ -80,6 +81,7 @@ describe('<SecureRoute />', () => {
 
     beforeEach(() => {
       authState.isAuthenticated = false;
+      authState.isPending = false;
     });
 
     it('will not render wrapped component using "component"', () => {
@@ -160,165 +162,127 @@ describe('<SecureRoute />', () => {
       });
     });
   });
-  
-  it('should accept a "path" prop and render a component', () => {
-    const wrapper = mount(
-      <MemoryRouter>
-        <Security {...mockProps}>
-          <SecureRoute
-            path='/'
-          />
-        </Security>
-      </MemoryRouter>
-    );
-    expect(wrapper.find(SecureRoute).props().path).toBe('/');
-  });
 
-  it('should accept an "exact" prop and render a component', () => {
-    const wrapper = mount(
-      <MemoryRouter>
-        <Security {...mockProps}>
-          <SecureRoute
-            exact={true}
-            path='/'
-          />
-        </Security>
-      </MemoryRouter>
-    );
-    expect(wrapper.find(SecureRoute).props().exact).toBe(true);
-  });
+  describe('when authenticated', () => { 
+    const MyComponent = function() { return <div>hello world</div>; };
+    beforeEach(() => {
+      authState.isPending = false;
+      authState.isAuthenticated = true;
+    });
 
-  it('should not contain an "exact" prop and render a component', () => {
-    const wrapper = mount(
-      <MemoryRouter>
-        <Security {...mockProps}>
-          <SecureRoute
-            path='/'
-          />
-        </Security>
-      </MemoryRouter>
-    );
-    expect(wrapper.find(SecureRoute).props().exact).toBeUndefined();
-  });
+    it('should accept a "path" prop and render a component', () => {
+      const wrapper = mount(
+        <MemoryRouter>
+          <Security {...mockProps}>
+            <SecureRoute
+              path='/'
+              component={MyComponent}
+            />
+          </Security>
+        </MemoryRouter>
+      );
+      expect(wrapper.find(SecureRoute).props().path).toBe('/');
+      expect(wrapper.find(MyComponent).html()).toBe('<div>hello world</div>');
+    });
 
-  it('should accept a "strict" prop and render a component', () => {
-    const wrapper = mount(
-      <MemoryRouter>
-        <Security {...mockProps}>
-          <SecureRoute
-            strict={true}
-            path='/'
-          />
-        </Security>
-      </MemoryRouter>
-    );
-    expect(wrapper.find(SecureRoute).props().strict).toBe(true);
-  });
+    it('should accept an "exact" prop and pass it to an internal Route', () => {
+      const wrapper = mount(
+        <MemoryRouter>
+          <Security {...mockProps}>
+            <SecureRoute
+              exact={true}
+              path='/'
+              component={MyComponent}
+            />
+          </Security>
+        </MemoryRouter>
+      );
+      const secureRoute = wrapper.find(SecureRoute);
+      expect(secureRoute.find(Route).props().exact).toBe(true);
+      expect(wrapper.find(MyComponent).html()).toBe('<div>hello world</div>');
+    });
 
-  it('should accept a "sensitive" prop and render a component', () => {
-    const wrapper = mount(
-      <MemoryRouter>
-        <Security {...mockProps}>
-          <SecureRoute
-            sensitive={true}
-            path='/'
-          />
-        </Security>
-      </MemoryRouter>
-    );
-    expect(wrapper.find(SecureRoute).props().sensitive).toBe(true);
-  });
+    it('should accept a "strict" prop and pass it to an internal Route', () => {
+      const wrapper = mount(
+        <MemoryRouter>
+          <Security {...mockProps}>
+            <SecureRoute
+              strict={true}
+              path='/'
+              component={MyComponent}
+            />
+          </Security>
+        </MemoryRouter>
+      );
+      const secureRoute = wrapper.find(SecureRoute);
+      expect(secureRoute.find(Route).props().strict).toBe(true);
+      expect(wrapper.find(MyComponent).html()).toBe('<div>hello world</div>');
+    });
 
-  it('should accept an "exact" prop and pass it to an internal Route', () => {
-    const wrapper = mount(
-      <MemoryRouter>
-        <Security {...mockProps}>
-          <SecureRoute
-            exact={true}
-            path='/'
-          />
-        </Security>
-      </MemoryRouter>
-    );
-    const secureRoute = wrapper.find(SecureRoute);
-    expect(secureRoute.find(Route).props().exact).toBe(true);
-  });
+    it('should accept a "sensitive" prop and pass it to an internal Route', () => {
+      const wrapper = mount(
+        <MemoryRouter>
+          <Security {...mockProps}>
+            <SecureRoute
+              sensitive={true}
+              path='/'
+              component={MyComponent}
+            />
+          </Security>
+        </MemoryRouter>
+      );
+      const secureRoute = wrapper.find(SecureRoute);
+      expect(secureRoute.find(Route).props().sensitive).toBe(true);
+      expect(wrapper.find(MyComponent).html()).toBe('<div>hello world</div>');
+    });
 
-  it('should accept a "strict" prop and pass it to an internal Route', () => {
-    const wrapper = mount(
-      <MemoryRouter>
-        <Security {...mockProps}>
-          <SecureRoute
-            strict={true}
-            path='/'
-          />
-        </Security>
-      </MemoryRouter>
-    );
-    const secureRoute = wrapper.find(SecureRoute);
-    expect(secureRoute.find(Route).props().strict).toBe(true);
-  });
+    it('should pass react-router props to an component', () => {
+      authState.isAuthenticated = true;
+      const MyComponent = function(props) { return <div>{ props.history ? 'has history' : 'lacks history'}</div>; };
+      const wrapper = mount(
+        <MemoryRouter>
+          <Security {...mockProps}>
+            <SecureRoute
+              path='/'
+              component={MyComponent}
+            />
+          </Security>
+        </MemoryRouter>
+      );
+      expect(wrapper.find(MyComponent).html()).toBe('<div>has history</div>');
+    });
 
-  it('should accept a "sensitive" prop and pass it to an internal Route', () => {
-    const wrapper = mount(
-      <MemoryRouter>
-        <Security {...mockProps}>
-          <SecureRoute
-            sensitive={true}
-            path='/'
-          />
-        </Security>
-      </MemoryRouter>
-    );
-    const secureRoute = wrapper.find(SecureRoute);
-    expect(secureRoute.find(Route).props().sensitive).toBe(true);
-  });
+    it('should pass react-router props to a render call', () => {
+      authState.isAuthenticated = true;
+      const MyComponent = function(props) { return <div>{ props.history ? 'has history' : 'lacks history'}</div>; };
+      const wrapper = mount(
+        <MemoryRouter>
+          <Security {...mockProps}>
+            <SecureRoute
+              path='/'
+              render = {props => <MyComponent {...props} />}
+            />
+          </Security>
+        </MemoryRouter>
+      );
+      expect(wrapper.find(MyComponent).html()).toBe('<div>has history</div>');
+    });
 
-  it('should pass react-router props to an component', () => {
-    authState.isAuthenticated = true;
-    const MyComponent = function(props) { return <div>{ props.history ? 'has history' : 'lacks history'}</div>; };
-    const wrapper = mount(
-      <MemoryRouter>
-        <Security {...mockProps}>
-          <SecureRoute
-            path='/'
-            component={MyComponent}
-          />
-        </Security>
-      </MemoryRouter>
-    );
-    expect(wrapper.find(MyComponent).html()).toBe('<div>has history</div>');
-  });
+    it('should pass props using the "render" prop', () => {
+      authState.isAuthenticated = true;
+      const MyComponent = function(props) { return <div>{ props.someProp ? 'has someProp' : 'lacks someProp'}</div>; };
+      const wrapper = mount(
+        <MemoryRouter>
+          <Security {...mockProps}>
+            <SecureRoute
+              path='/'
+              render={ () => <MyComponent someProp={true}/> }
+            />
+          </Security>
+        </MemoryRouter>
+      );
+      expect(wrapper.find(MyComponent).html()).toBe('<div>has someProp</div>');
+    });
 
-  it('should pass react-router props to a render call', () => {
-    authState.isAuthenticated = true;
-    const MyComponent = function(props) { return <div>{ props.history ? 'has history' : 'lacks history'}</div>; };
-    const wrapper = mount(
-      <MemoryRouter>
-        <Security {...mockProps}>
-          <SecureRoute
-            path='/'
-            render = {props => <MyComponent {...props} />}
-          />
-        </Security>
-      </MemoryRouter>
-    );
-    expect(wrapper.find(MyComponent).html()).toBe('<div>has history</div>');
-  });
-
-  it('should pass props using the "render" prop', () => {
-    authState.isAuthenticated = true;
-    const MyComponent = function(props) { return <div>{ props.someProp ? 'has someProp' : 'lacks someProp'}</div>; };
-    const wrapper = mount(
-      <MemoryRouter>
-        <Security {...mockProps}>
-          <SecureRoute
-            path='/'
-            render={ () => <MyComponent someProp={true}/> }
-          />
-        </Security>
-      </MemoryRouter>
-    );
-    expect(wrapper.find(MyComponent).html()).toBe('<div>has someProp</div>');
   });
 });

--- a/packages/okta-react/test/jest/secureRoute.test.js
+++ b/packages/okta-react/test/jest/secureRoute.test.js
@@ -33,7 +33,7 @@ describe('<SecureRoute />', () => {
       authState.isAuthenticated = true;
     });
 
-    it('will render wrapped component', () => {
+    it('will render wrapped component using "component"', () => {
       const MyComponent = function() { return <div>hello world</div>; };
       const wrapper = mount(
         <MemoryRouter>
@@ -41,6 +41,34 @@ describe('<SecureRoute />', () => {
             <SecureRoute
               component={MyComponent}
             />
+          </Security>
+        </MemoryRouter>
+      );
+      expect(wrapper.find(MyComponent).html()).toBe('<div>hello world</div>');
+    });
+
+    it('will render wrapped component using "render"', () => {
+      const MyComponent = function() { return <div>hello world</div>; };
+      const wrapper = mount(
+        <MemoryRouter>
+          <Security {...mockProps}>
+            <SecureRoute
+              render={ () => <MyComponent/> }
+            />
+          </Security>
+        </MemoryRouter>
+      );
+      expect(wrapper.find(MyComponent).html()).toBe('<div>hello world</div>');
+    });
+
+    it('will render wrapped component as a child', () => {
+      const MyComponent = function() { return <div>hello world</div>; };
+      const wrapper = mount(
+        <MemoryRouter>
+          <Security {...mockProps}>
+            <SecureRoute>
+              <MyComponent/>
+            </SecureRoute>
           </Security>
         </MemoryRouter>
       );
@@ -54,7 +82,7 @@ describe('<SecureRoute />', () => {
       authState.isAuthenticated = false;
     });
 
-    it('will not render wrapped component', () => {
+    it('will not render wrapped component using "component"', () => {
       const MyComponent = function() { return <div>hello world</div>; };
       const wrapper = mount(
         <MemoryRouter>
@@ -62,6 +90,34 @@ describe('<SecureRoute />', () => {
             <SecureRoute
               component={MyComponent}
             />
+          </Security>
+        </MemoryRouter>
+      );
+      expect(wrapper.find(MyComponent).length).toBe(0);
+    });
+
+    it('will not render wrapped component using "render"', () => {
+      const MyComponent = function() { return <div>hello world</div>; };
+      const wrapper = mount(
+        <MemoryRouter>
+          <Security {...mockProps}>
+            <SecureRoute
+              render={ () => <MyComponent/> }
+            />
+          </Security>
+        </MemoryRouter>
+      );
+      expect(wrapper.find(MyComponent).length).toBe(0);
+    });
+
+   it('will not render wrapped component with children', () => {
+      const MyComponent = function() { return <div>hello world</div>; };
+      const wrapper = mount(
+        <MemoryRouter>
+          <Security {...mockProps}>
+            <SecureRoute>
+              <MyComponent/>
+            </SecureRoute>
           </Security>
         </MemoryRouter>
       );
@@ -218,7 +274,7 @@ describe('<SecureRoute />', () => {
     expect(secureRoute.find(Route).props().sensitive).toBe(true);
   });
 
-  it('should pass react-router props to an internal Route component', () => {
+  it('should pass react-router props to an component', () => {
     authState.isAuthenticated = true;
     const MyComponent = function(props) { return <div>{ props.history ? 'has history' : 'lacks history'}</div>; };
     const wrapper = mount(
@@ -227,6 +283,22 @@ describe('<SecureRoute />', () => {
           <SecureRoute
             path='/'
             component={MyComponent}
+          />
+        </Security>
+      </MemoryRouter>
+    );
+    expect(wrapper.find(MyComponent).html()).toBe('<div>has history</div>');
+  });
+
+  it('should pass react-router props to a render call', () => {
+    authState.isAuthenticated = true;
+    const MyComponent = function(props) { return <div>{ props.history ? 'has history' : 'lacks history'}</div>; };
+    const wrapper = mount(
+      <MemoryRouter>
+        <Security {...mockProps}>
+          <SecureRoute
+            path='/'
+            render = {props => <MyComponent {...props} />}
           />
         </Security>
       </MemoryRouter>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, only "component" arguments to `<SecureRoute>` actually enforced authentication

Issue Number: https://github.com/okta/okta-oidc-js/issues/808


## What is the new behavior?

With this change, `<SecureRoute>` adds formal support for "component", "render", and "children" just as `<Route>` from react-router-dom.  

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No (w/caveat)

Note that the wrapping layers around a secured component now pull out all three potential params (component/render/children), which means not all three are passed through all the layers, which is for the best to avoid undetermined behavior with react-router, but we do have devs that have reported using such constructions. 

This should follow the same priority order as react-router, but there is a risk of impact to those devs (though using render() was technically undocumented)
 

## Other information


## Reviewers

