### PR TITLE
Adds i18n config test to be used in widget PDV

### DIFF
--- a/packages/oidc-middleware/test/e2e/harness/start-custom-login-server.js
+++ b/packages/oidc-middleware/test/e2e/harness/start-custom-login-server.js
@@ -12,9 +12,10 @@
 
 const constants = require('../util/constants');
 const util = require('../util/util');
+let options = {};
+let cdnUrl = 'https://global.oktacdn.com/okta-signin-widget/4.4.1';
 
-let cdnUrl='https://ok1static.oktacdn.com/assets/js/sdk/okta-signin-widget/3.0.0';
-
+// This is used as PDV for widget after artifact promotion to CDN
 if(process.env.NPM_TARBALL_URL) {
   // Extract the version of sign-in widget from the NPM_TARBALL_URL variable
   // The variable is of the format https:<artifactory_url>/@okta/okta-signin-widget-3.0.6.tgz
@@ -22,6 +23,14 @@ if(process.env.NPM_TARBALL_URL) {
   const i = url.lastIndexOf('-');
   const version = url.substring(i + 1, url.length - 4);
   cdnUrl=`https://global.oktacdn.com/okta-signin-widget/${version}`;
+
+  // We also test i18n assets on CDN
+  options.language = 'fr';
+  options.i18n = {
+    fr: {
+      'primaryauth.title': 'Connectez-vous à Acme',
+    }
+  }
 }
 console.log(`Using CDN url - ${cdnUrl}`);
 
@@ -33,7 +42,8 @@ const serverOptions = {
   testing: {
     disableHttpsCheck: constants.OKTA_TESTING_DISABLEHTTPSCHECK
   },
-  cdnUrl: cdnUrl
+  cdnUrl: cdnUrl,
+  options: options
 }
 
 console.log('serverOptions', serverOptions);

--- a/packages/oidc-middleware/test/e2e/harness/start-custom-login-server.js
+++ b/packages/oidc-middleware/test/e2e/harness/start-custom-login-server.js
@@ -12,27 +12,7 @@
 
 const constants = require('../util/constants');
 const util = require('../util/util');
-let options = {};
-let cdnUrl = 'https://global.oktacdn.com/okta-signin-widget/4.4.1';
-
-// This is used as PDV for widget after artifact promotion to CDN
-if(process.env.NPM_TARBALL_URL) {
-  // Extract the version of sign-in widget from the NPM_TARBALL_URL variable
-  // The variable is of the format https:<artifactory_url>/@okta/okta-signin-widget-3.0.6.tgz
-  const url = process.env.NPM_TARBALL_URL;
-  const i = url.lastIndexOf('-');
-  const version = url.substring(i + 1, url.length - 4);
-  cdnUrl=`https://global.oktacdn.com/okta-signin-widget/${version}`;
-
-  // We also test i18n assets on CDN
-  options.language = 'fr';
-  options.i18n = {
-    fr: {
-      'primaryauth.title': 'Connectez-vous à Acme',
-    }
-  }
-}
-console.log(`Using CDN url - ${cdnUrl}`);
+const cdnUrl = 'https://global.oktacdn.com/okta-signin-widget/4.4.1';
 
 const serverOptions = {
   issuer: constants.ISSUER,
@@ -42,8 +22,7 @@ const serverOptions = {
   testing: {
     disableHttpsCheck: constants.OKTA_TESTING_DISABLEHTTPSCHECK
   },
-  cdnUrl: cdnUrl,
-  options: options
+  cdnUrl: cdnUrl
 }
 
 console.log('serverOptions', serverOptions);

--- a/packages/oidc-middleware/test/e2e/harness/views/login.ejs
+++ b/packages/oidc-middleware/test/e2e/harness/views/login.ejs
@@ -13,8 +13,18 @@
     <div id="banner"><center>Custom Login Page</center></div>
     <div id="app-container"></div>
     <script type="text/javascript">
+      console.log('<%= baseUrl %>');
       const signIn = new OktaSignIn({
-        baseUrl: '<%= baseUrl %>'  // e.g. https://dev-1234.oktapreview.com
+        baseUrl: '<%= baseUrl %>',  // e.g. https://dev-1234.oktapreview.com
+        language: '<%= language %>',
+        i18n: {
+          en: {
+            'primaryauth.title': 'Sign in to Acme',
+          },
+          fr: {
+            'primaryauth.title': 'Connectez-vous à Acme',
+          }
+        }
       });
 
       signIn.renderEl({ el: '#app-container' }, (res) => {

--- a/packages/oidc-middleware/test/e2e/page-objects/CustomLoginPage.js
+++ b/packages/oidc-middleware/test/e2e/page-objects/CustomLoginPage.js
@@ -18,6 +18,9 @@ module.exports = class OktaSignInPage {
     this.password = $('[name=password]');
     this.submit = $('#okta-signin-submit');
     this.banner = $('#banner');
+    this.pageTitle = $('[data-se=o-form-head]');
+    this.usernameLabel = $('[data-se=o-form-label] [for=okta-signin-username]');
+    this.passwordLabel = $('[data-se=o-form-label] [for=okta-signin-password]');
   }
 
   async load() {

--- a/packages/oidc-middleware/test/e2e/specs/custom-login-page.js
+++ b/packages/oidc-middleware/test/e2e/specs/custom-login-page.js
@@ -20,8 +20,9 @@ browser.waitForAngularEnabled(false);
 describe('Custom login page', () => {
   let server;
   beforeEach(async () => {
-    let cdnUrl='https://ok1static.oktacdn.com/assets/js/sdk/okta-signin-widget/3.0.0';
-
+    let cdnUrl = 'https://global.oktacdn.com/okta-signin-widget/4.4.1';
+    let options = {};
+    // This is used as PDV for widget after artifact promotion to CDN
     if(process.env.NPM_TARBALL_URL) {
       // Extract the version of sign-in widget from the NPM_TARBALL_URL variable
       // The variable is of the format https:<artifactory_url>/@okta/okta-signin-widget-3.0.6.tgz
@@ -29,6 +30,13 @@ describe('Custom login page', () => {
       const i = url.lastIndexOf('-');
       const version = url.substring(i + 1, url.length - 4);
       cdnUrl=`https://global.oktacdn.com/okta-signin-widget/${version}`;
+      // We also test i18n assets on CDN
+      options.language = 'fr';
+      options.i18n = {
+        fr: {
+          'primaryauth.title': 'Connectez-vous à Acme',
+        }
+      }
     }
     console.log(`Using CDN url - ${cdnUrl}`);
 
@@ -40,7 +48,8 @@ describe('Custom login page', () => {
       testing: {
         disableHttpsCheck: constants.OKTA_TESTING_DISABLEHTTPSCHECK
       },
-      cdnUrl: cdnUrl
+      cdnUrl: cdnUrl,
+      options: options
     }
 
     server = util.createDemoServerWithCustomLoginPage(serverOptions);
@@ -56,6 +65,13 @@ describe('Custom login page', () => {
     // eslint-disable-next-line protractor/no-browser-sleep
     await browser.sleep(3000);
     await signInPage.waitUntilVisible();
+
+    // If we're testing widget i18n options (widget PDV)
+    if(process.env.NPM_TARBALL_URL) {
+      expect(signInPage.pageTitle.getText()).toBe('Connectez-vous à Acme');
+      expect(signInPage.usernameLabel.getText()).toBe('Nom d\'utilisateur ');
+      expect(signInPage.passwordLabel.getText()).toBe('Mot de passe ');
+    }
 
     await signInPage.signIn({
       username: constants.USERNAME,

--- a/packages/oidc-middleware/test/e2e/specs/custom-login-page.js
+++ b/packages/oidc-middleware/test/e2e/specs/custom-login-page.js
@@ -20,16 +20,17 @@ browser.waitForAngularEnabled(false);
 describe('Custom login page', () => {
   let server;
   beforeEach(async () => {
-    let cdnUrl = 'https://global.oktacdn.com/okta-signin-widget/4.4.1';
-    let options = {};
+    let widgetVersion = '4.4.1';
+    const options = {};
+
     // This is used as PDV for widget after artifact promotion to CDN
     if(process.env.NPM_TARBALL_URL) {
       // Extract the version of sign-in widget from the NPM_TARBALL_URL variable
       // The variable is of the format https:<artifactory_url>/@okta/okta-signin-widget-3.0.6.tgz
       const url = process.env.NPM_TARBALL_URL;
       const i = url.lastIndexOf('-');
-      const version = url.substring(i + 1, url.length - 4);
-      cdnUrl=`https://global.oktacdn.com/okta-signin-widget/${version}`;
+      widgetVersion = url.substring(i + 1, url.length - 4);
+
       // We also test i18n assets on CDN
       options.language = 'fr';
       options.i18n = {
@@ -38,6 +39,7 @@ describe('Custom login page', () => {
         }
       }
     }
+    const cdnUrl = `https://global.oktacdn.com/okta-signin-widget/${widgetVersion}`;
     console.log(`Using CDN url - ${cdnUrl}`);
 
     const serverOptions = {

--- a/packages/oidc-middleware/test/e2e/util/util.js
+++ b/packages/oidc-middleware/test/e2e/util/util.js
@@ -36,10 +36,13 @@ util.createDemoServerWithCustomLoginPage = (options) => {
       login: {
         viewHandler: (req, res/*, next */) => {
           const baseUrl = url.parse(baseConfig.issuer).protocol + '//' + url.parse(baseConfig.issuer).host;
+
           res.render('login', {
             csrfToken: req.csrfToken(),
             baseUrl: baseUrl,
-            cdnUrl: baseConfig.cdnUrl
+            cdnUrl: baseConfig.cdnUrl,
+            language: baseConfig.options.language,
+            i18n: baseConfig.options.i18n
           });
         }
       }


### PR DESCRIPTION
* We use oidc-middleware custom sign-in page test as PDV for widget global CDN 
* This PR extends the test to include i18n options to catch issues like [this](https://github.com/okta/okta-signin-widget/issues/1398)
* Since we already run this test on bacon as PDV, adding i18n test to this repo will get us more coverage without any setup effort (as opposed to adding it in widget repo, in which case we have to setup new tests in bacon)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

