### PR TITLE
Updates the custom server start script

### DIFF
--- a/packages/oidc-middleware/test/e2e/harness/start-custom-login-server.js
+++ b/packages/oidc-middleware/test/e2e/harness/start-custom-login-server.js
@@ -12,7 +12,28 @@
 
 const constants = require('../util/constants');
 const util = require('../util/util');
-const cdnUrl = 'https://global.oktacdn.com/okta-signin-widget/4.4.1';
+let widgetVersion = '4.4.1';
+const options = {};
+
+// This is used as PDV for widget after artifact promotion to CDN
+if(process.env.NPM_TARBALL_URL) {
+  // Extract the version of sign-in widget from the NPM_TARBALL_URL variable
+  // The variable is of the format https:<artifactory_url>/@okta/okta-signin-widget-3.0.6.tgz
+  const url = process.env.NPM_TARBALL_URL;
+  const i = url.lastIndexOf('-');
+  widgetVersion = url.substring(i + 1, url.length - 4);
+
+  // We also test i18n assets on CDN
+  options.language = 'fr';
+  options.i18n = {
+    fr: {
+      'primaryauth.title': 'Connectez-vous à Acme',
+    }
+  }
+}
+
+const cdnUrl = `https://global.oktacdn.com/okta-signin-widget/${widgetVersion}`;
+console.log(`Using CDN url - ${cdnUrl}`);
 
 const serverOptions = {
   issuer: constants.ISSUER,
@@ -22,7 +43,8 @@ const serverOptions = {
   testing: {
     disableHttpsCheck: constants.OKTA_TESTING_DISABLEHTTPSCHECK
   },
-  cdnUrl: cdnUrl
+  cdnUrl: cdnUrl,
+  options: options
 }
 
 console.log('serverOptions', serverOptions);


### PR DESCRIPTION
- I recently made a change to oidc-middleware custom login tests to add support for widget PDV
- But in doing so, I broke the start server script since I didn't add those changes there.
- Fixes the following error I get while starting the server - 

<img width="1260" alt="Screen Shot 2020-09-04 at 3 12 58 PM" src="https://user-images.githubusercontent.com/27521424/92289366-18c8c400-eec5-11ea-8e73-07539f2873ac.png">

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [guidelines](/okta/okta-oidc-js/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

