### PR TITLE
Custom JWKS URI (copy)

### DIFF
--- a/packages/jwt-verifier/CHANGELOG.md
+++ b/packages/jwt-verifier/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.3.0
+
+### Features
+
+- [#708](https://github.com/okta/okta-oidc-js/pull/708) - Adds support for custom JWKS URI when it cannot be constructed from issuer URI
+
 # 2.2.0
 
 ### Other

--- a/packages/jwt-verifier/README.md
+++ b/packages/jwt-verifier/README.md
@@ -160,7 +160,7 @@ Custom JWKS URI can be provided. It's useful when JWKS URI cannot be based on Is
 const verifier = new OktaJwtVerifier({
   issuer: 'https://{yourOktaDomain}',
   clientId: '{clientId}',
-  jwksUri: 'https://https://{yourOktaDomain}/oauth2/v1/keys'
+  jwksUri: 'https://{yourOktaDomain}/oauth2/v1/keys'
 });
 ```
 

--- a/packages/jwt-verifier/README.md
+++ b/packages/jwt-verifier/README.md
@@ -152,6 +152,18 @@ The values you want to assert are always represented as an array (the right side
 
 NOTE: Currently, `.includes` is the only supported claim operator.
 
+## Custom JWKS URI
+
+Custom JWKS URI can be provided. It's useful when JWKS URI cannot be based on Issuer URI:
+
+```javascript
+const verifier = new OktaJwtVerifier({
+  issuer: 'https://{yourOktaDomain}',
+  clientId: '{clientId}',
+  jwksUri: 'https://https://{yourOktaDomain}/oauth2/v1/keys'
+});
+```
+
 ## Caching & Rate Limiting
 
 * By default, found keys are cached by key ID for one hour. This can be configured with the `cacheMaxAge` option for cache entries.

--- a/packages/jwt-verifier/lib.js
+++ b/packages/jwt-verifier/lib.js
@@ -161,6 +161,10 @@ function verifyNonce(expected, nonce) {
   }
 }
 
+function getJwksUri(options) {
+  return options.jwksUri ? options.jwksUri : options.issuer + '/v1/keys';
+}
+
 class OktaJwtVerifier {
   constructor(options = {}) {
     // Assert configuration options exist and are well-formed (not necessarily correct!)
@@ -171,8 +175,9 @@ class OktaJwtVerifier {
 
     this.claimsToAssert = options.assertClaims || {};
     this.issuer = options.issuer;
+    this.jwksUri = getJwksUri(options);
     this.jwksClient = jwksClient({
-      jwksUri: `${options.issuer}/v1/keys`,
+      jwksUri: this.jwksUri,
       cache: true,
       cacheMaxAge: options.cacheMaxAge || (60 * 60 * 1000),
       cacheMaxEntries: 3,

--- a/packages/jwt-verifier/package.json
+++ b/packages/jwt-verifier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okta/jwt-verifier",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Easily validate Okta access tokens",
   "repository": "https://github.com/okta/okta-oidc-js",
   "homepage": "https://github.com/okta/okta-oidc-js/tree/master/packages/jwt-verifier",

--- a/packages/jwt-verifier/test/spec/configuration.spec.js
+++ b/packages/jwt-verifier/test/spec/configuration.spec.js
@@ -87,4 +87,39 @@ describe('jwt-verifier configuration validation', () => {
     expect(createInstance).not.toThrow();
   });
 
+  it('should return issuer-based jwks uri when custom jwksUri is not specified', () => {
+
+    const verifier = new OktaJwtVerifier({
+      issuer: 'https://foo',
+      clientId: '123456',
+    });
+
+    expect(verifier.jwksUri).toEqual('https://foo/v1/keys');
+  });
+
+  [undefined, ''].forEach(jwksUri =>
+    it(`should return issuer-based jwks uri when jwks custom uri is ${jwksUri}`, () => {
+
+      const verifier = new OktaJwtVerifier({
+        issuer: 'https://foo',
+        clientId: '123456',
+        jwksUri: jwksUri
+      });
+
+      expect(verifier.jwksUri).toEqual('https://foo/v1/keys');
+    })
+  );
+
+  it('should return custom jwks uri when specified', () => {
+
+    const customJwksUri = 'http://custom-jwks-uri/keys';
+
+    const verifier = new OktaJwtVerifier({
+      issuer: 'https://foo',
+      clientId: '123456',
+      jwksUri: customJwksUri
+    });
+
+    expect(verifier.jwksUri).toEqual(customJwksUri);
+  });
 });


### PR DESCRIPTION
Copy of https://github.com/okta/okta-oidc-js/pull/708

JWKS URI can be constructed either by appending '/v1/keys' to Issuer URI or it could be provided in options in 'jwksUri' field.